### PR TITLE
fix: resolve three stubs/bugs, add CLAUDE.md, and fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,5 @@ backend/alembic/env.py
 check-all.sh
 rebuild-dev.sh
 
-*.md
-*.MD
 frontend_legacy/
 backend_legacy/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,94 @@
+# CLAUDE.md — Dental Lab Management App
+
+## Project overview
+
+A web application for Slovak dental laboratories: manage patients, jobs (dental work orders), clinics, doctors, technicians, inventory, and invoicing.
+
+**Target market:** Slovak dental labs (UI is partially localised in Slovak).
+
+## Tech stack
+
+| Layer | Technology |
+|---|---|
+| Backend | Django 5 + Django REST Framework, SimpleJWT |
+| Frontend | React 19, Vite, Tailwind CSS, Zustand (auth store) |
+| Database | PostgreSQL (via Docker) |
+| Dev environment | Docker Compose |
+| API docs | Swagger UI at `/api/docs/` |
+
+## Active branch
+
+**`develop`** is the working branch. `main` is stale (predates the Django+React refactor).
+
+## Running the dev environment
+
+```bash
+# Start everything (backend + frontend + postgres)
+docker compose up
+
+# Or rebuild from scratch
+./rebuild-dev
+
+# Seed demo data
+docker compose exec backend python manage.py runscript seed_data
+# or
+docker compose exec backend python seed_data.py
+```
+
+Default credentials after seeding: `admin` / `admin` and `user` / `user`.
+
+Frontend dev server: http://localhost:5173  
+Backend API: http://localhost:8000/api/  
+Swagger docs: http://localhost:8000/api/docs/
+
+## Running tests
+
+```bash
+# Backend (Django)
+docker compose exec backend python manage.py test --verbosity=2
+
+# Frontend (lint + build check — no Jest tests yet)
+cd frontend && npm run lint && npm run build
+```
+
+## Architecture — Django apps
+
+| App | Domain |
+|---|---|
+| `apps/core` | Users (`User` model extending `AbstractUser`), Labs, authentication |
+| `apps/crm` | Patients, Clinics, Doctors |
+| `apps/jobs` | Jobs (work orders), Technicians, Vacations |
+| `apps/finance` | Invoices, PriceList, Subscriptions |
+| `apps/inventory` | Warehouse items |
+
+Root-level API router (`config/urls.py`) exposes shortcuts: `/api/users/`, `/api/labs/`, `/api/invoices/`, `/api/warehouse/`, `/api/vacations/`.  
+App-scoped routers: `/api/crm/`, `/api/jobs/`, `/api/finance/`, `/api/inventory/`.
+
+## Key conventions
+
+- All ViewSets filter by `request.user.lab` so data is tenant-isolated per lab.
+- Superadmin users (`role == "superadmin"`) bypass lab filters and see all data.
+- Job status flow: `new` → `in_progress` → `completed` / `cancelled`. When invoiced, finance views additionally set `finished_factured`, `finished_unfactured`, or `closed` (see `apps/finance/views.py:_sync_jobs_for_invoice_status`).
+
+## Known incomplete areas (open issues)
+
+| # | Area | Status |
+|---|---|---|
+| #34 | Job status mismatch in finance views | **Fixed** — migration `0004_add_billing_job_statuses` added |
+| #35 | LabSettings save was a placeholder | **Fixed** — now calls `PATCH /api/labs/<id>/` |
+| #36 | Password change in ProfileSettings | **Fixed** — now calls `PUT /api/users/me/` |
+| #37 | Finance dashboard is a stub | Open — needs real stats endpoint |
+| #38 | Dashboard loads all data for 4 stats | Open — needs `/api/dashboard/stats/` |
+| #39 | Inventory CSV import is sequential | Open — needs bulk import endpoint |
+| #40 | Mixed Slovak/English UI | Open — language decision needed |
+| #41 | Wrong repo URL in root package.json | **Fixed** |
+| #42 | Stale branches on GitHub | Open — delete manually |
+| #43 | Missing CLAUDE.md | **Fixed** (this file) |
+
+## Documentation
+
+The `doc/` directory contains:
+- `requirements.md` — original Slovak requirements spec
+- `testing.md` — testing strategy
+- `test_coverage.md` — test coverage summary
+- `github_actions_fix.md` — notes on CI pipeline

--- a/backend/apps/jobs/migrations/0004_add_billing_job_statuses.py
+++ b/backend/apps/jobs/migrations/0004_add_billing_job_statuses.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("jobs", "0003_alter_job_doctor"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="job",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("new", "New"),
+                    ("in_progress", "In Progress"),
+                    ("completed", "Completed"),
+                    ("cancelled", "Cancelled"),
+                    ("finished_factured", "Finished \u2013 Factured"),
+                    ("finished_unfactured", "Finished \u2013 Unfactured"),
+                    ("closed", "Closed"),
+                ],
+                default="new",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/backend/apps/jobs/models.py
+++ b/backend/apps/jobs/models.py
@@ -23,6 +23,9 @@ class Job(models.Model):
         ("in_progress", "In Progress"),
         ("completed", "Completed"),
         ("cancelled", "Cancelled"),
+        ("finished_factured", "Finished – Factured"),
+        ("finished_unfactured", "Finished – Unfactured"),
+        ("closed", "Closed"),
     )
 
     lab = models.ForeignKey(Lab, on_delete=models.CASCADE, related_name="jobs")

--- a/frontend/src/pages/LabSettings.jsx
+++ b/frontend/src/pages/LabSettings.jsx
@@ -6,6 +6,7 @@ import { Save, Loader2, AlertCircle } from 'lucide-react';
 
 export default function LabSettings() {
     const [loading, setLoading] = useState(true);
+    const [labId, setLabId] = useState(null);
     const [error, setError] = useState('');
     const [success, setSuccess] = useState('');
     const [formData, setFormData] = useState({
@@ -34,6 +35,7 @@ export default function LabSettings() {
             const response = await api.get('/labs/');
             if (response.data && response.data.length > 0) {
                 const lab = response.data[0]; // Get first (current) lab
+                setLabId(lab.id);
                 setFormData({
                     name: lab.name || '',
                     address: lab.address || '',
@@ -72,15 +74,19 @@ export default function LabSettings() {
             return;
         }
 
+        if (!labId) {
+            setError('No lab found. Cannot save settings.');
+            return;
+        }
+
         setLoading(true);
         try {
-            // Update lab - would need lab ID
-            // For now, this is a placeholder
-            setSuccess('Lab settings would be updated here');
-            setError('Lab update functionality not yet fully implemented');
+            await api.patch(`/labs/${labId}/`, formData);
+            setSuccess('Lab settings saved successfully');
         } catch (err) {
             console.error('Failed to update lab:', err);
-            setError('Failed to update lab settings');
+            const detail = err?.response?.data?.detail;
+            setError(typeof detail === 'string' ? detail : 'Failed to update lab settings');
         } finally {
             setLoading(false);
         }

--- a/frontend/src/pages/ProfileSettings.jsx
+++ b/frontend/src/pages/ProfileSettings.jsx
@@ -46,11 +46,13 @@ export default function ProfileSettings() {
 
         setLoading(true);
         try {
-            // Note: Password change endpoint might need to be implemented
-            setError('Password change functionality not yet implemented');
+            await api.put('/users/me/', { password: formData.newPassword });
+            setSuccess('Password updated successfully');
+            setFormData(prev => ({ ...prev, currentPassword: '', newPassword: '', confirmPassword: '' }));
         } catch (err) {
             console.error('Failed to change password:', err);
-            setError('Failed to change password');
+            const detail = err?.response?.data?.detail;
+            setError(typeof detail === 'string' ? detail : 'Failed to change password');
         } finally {
             setLoading(false);
         }

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/magula12/dental-app.git"
+    "url": "git+https://github.com/magi-9/dental-app.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "bugs": {
-    "url": "https://github.com/magula12/dental-app/issues"
+    "url": "https://github.com/magi-9/dental-app/issues"
   },
-  "homepage": "https://github.com/magula12/dental-app#readme"
+  "homepage": "https://github.com/magi-9/dental-app#readme"
 }


### PR DESCRIPTION
fix(jobs): add missing billing statuses to Job.STATUS_CHOICES (finished_factured, finished_unfactured, closed) with migration 0004 — fixes silent invalid-value writes from finance views (closes #34)

fix(frontend): wire up LabSettings save to PATCH /api/labs/<id>/ store lab id on load and call real API instead of placeholder (closes #35)

fix(frontend): wire up password change in ProfileSettings calls PUT /api/users/me/ with new password; clears fields on success (closes #36)

chore: fix root package.json repo URLs (magula12 → magi-9) (closes #41)

docs: add CLAUDE.md with project overview, dev setup, architecture map, and status table of all open issues

chore: remove *.md rule from .gitignore — was blocking all docs from being tracked

https://claude.ai/code/session_013k1pS8kwdsEucJpuXjfYnE