### PR TITLE
feat(security): JWT token blacklist, logout endpoint, brute-force protection

### DIFF
--- a/TASKS.MD
+++ b/TASKS.MD
@@ -1,0 +1,156 @@
+# BACKLOG
+<!-- 2 done / 43 total — 41 tasks left -->
+
+Severity: 🔴 Critical · 🟠 High · 🟡 Medium · ⚪ Low
+Effort:   💀 Hard · ⚡ Medium · ✅ Easy
+
+---
+
+## PR 1 — Security quick wins
+> 🔴 Critical · ✅ Easy · Do these first, independent of everything else.
+
+- [x] Enable `rest_framework_simplejwt.token_blacklist` in `INSTALLED_APPS` and call `token.blacklist()` on logout and password change (`api-client.js:248` + logout view)
+- [x] Add `AnonRateThrottle` scoped to `/api/token/` to block brute-force login attempts
+
+---
+
+## PR 2 — CI hardening
+> 🟠 High · ✅ Easy · All independent one-liners or small config changes.
+
+- [ ] Add `python manage.py migrate --check` as a CI step after checkout — missing migrations pass tests (Django builds test DB from scratch) but break on deploy
+- [ ] Add `--fail-under=80` (or chosen threshold) to the `coverage report` step so CI fails on coverage regression
+- [ ] Replace `black` + `flake8` with `ruff` — handles formatting, linting, and import ordering in one tool, faster in CI
+- [ ] Update `docker/login-action@v2` → v3 and `docker/build-push-action@v4` → v6 in `ci.yml`
+
+---
+
+## PR 3 — Production security headers
+> 🔴 Critical · ✅ Easy · Split settings, add headers, add CSP.
+
+- [ ] Split `backend/config/settings.py` into `settings/base.py` + `settings/production.py` + `settings/dev.py`
+- [ ] Add Django security headers in `production.py`: `SECURE_HSTS_SECONDS`, `SECURE_CONTENT_TYPE_NOSNIFF`, `X_FRAME_OPTIONS`, `SECURE_SSL_REDIRECT`
+- [ ] Add `Content-Security-Policy` header (via Django middleware or nginx config) — primary XSS blast-radius reduction before cookie migration lands
+
+---
+
+## PR 4 — Frontend source restructure
+> 🟠 High · ⚡ Medium · Move files, update imports, verify build.
+
+- [ ] Move all production React code from `frontend/public/design/` into `frontend/src/` with a proper module layout (`components/`, `hooks/`, `pages/`, `api/`)
+- [ ] Update `vite.config.js` entry points and verify `npm run build` passes after move
+- [ ] Update all relative import paths broken by the move
+
+---
+
+## PR 5 — Finance service extraction
+> 🟠 High · 💀 Hard · Modular monolith phase 1 — see `doc/modular_monolith_roadmap.md`.
+
+- [ ] Create `apps/finance/services.py`; extract invoice creation into `create_invoice_from_jobs(*, user, clinic_id, job_ids, document_type, discount_percent)`
+- [ ] Extract invoice number generation into `next_invoice_number(lab)` service function
+- [ ] Extract status change into `update_invoice_status(*, user, invoice, status)` — keep `transaction.atomic`, keep audit log call via `core.services.write_audit_log`
+- [ ] `InvoiceViewSet.create()` and `InvoiceViewSet.status()` delegate to service; ViewSet only validates HTTP input and returns serializer response
+
+---
+
+## PR 6 — Jobs service extraction
+> 🟠 High · 💀 Hard · Modular monolith phase 1 — finance stops writing directly to `Job`.
+
+- [ ] Create `apps/jobs/services.py`; extract job status transitions into `transition_job_status(*, user, job, new_status, note=None)`
+- [ ] Add finance-facing functions: `mark_jobs_invoiced(job_ids, *, invoice_status)` and `mark_jobs_invoice_cancelled(job_ids)` so finance never does `Job.objects.update(...)` directly
+- [ ] Update `apps/finance/views.py` `_sync_jobs_for_invoice_status` to call `jobs.services` instead of direct ORM writes
+
+---
+
+## PR 7 — Tenant selectors
+> 🟠 High · ⚡ Medium · Modular monolith phase 2 — one source of truth for tenant scoping.
+
+- [ ] Create `apps/jobs/selectors.py`: `jobs_for_user(user)`, `technicians_for_user(user)`, `calendar_events_for_user(user)`
+- [ ] Create `apps/finance/selectors.py`: `invoices_for_user(user)`, `price_list_for_user(user)`
+- [ ] Create `apps/crm/selectors.py`: `patients_for_user(user)`, `clinics_for_user(user)`, `doctors_for_user(user)`; ViewSet `get_queryset()` methods use selectors instead of repeating tenant filter logic
+
+---
+
+## PR 8 — JWT httpOnly cookie migration
+> 🔴 Critical · 💀 Hard · Full auth surface change — do after service extraction stabilises.
+
+- [ ] Backend: configure `JWTCookieAuthentication` (via `dj-rest-auth` or manual SimpleJWT cookie view) to set `access` and `refresh` as `httpOnly; Secure; SameSite=Strict` cookies
+- [ ] Frontend: remove `localStorage.setItem/getItem` for tokens in `api-client.js`; remove `Authorization` header injection; rely on browser cookie auto-send
+- [ ] Re-enable `CsrfViewMiddleware` for state-changing endpoints; send CSRF token in request header from frontend; verify `CORS_ALLOW_CREDENTIALS = True` is still correct
+
+---
+
+## PR 9 — Role matrix and permissions tests
+> 🟠 High · ⚡ Medium · Expand existing test matrix — tenant isolation is a security rule.
+
+- [ ] Add cross-lab access tests: verify superadmin sees all labs, admin/user/technician see only their own lab across all main endpoints
+- [ ] Add write-operation role tests: non-admin roles cannot create/update/delete in CRM, jobs, finance, inventory
+- [ ] Add tests for root-level API aliases (`/api/invoices/`, `/api/warehouse/`, `/api/vacations/`) to confirm they enforce the same tenant isolation as app-scoped routes
+
+---
+
+## PR 10 — Playwright smoke tests
+> 🟡 Medium · ⚡ Medium · Covers user journeys that lint+build cannot catch.
+
+- [ ] Login / logout flow (valid credentials, wrong password, session expiry)
+- [ ] Create patient → create job → assign technician flow
+- [ ] Invoice creation from jobs → status change to paid → verify job status syncs to `closed`
+- [ ] Permissions screen: verify non-admin cannot access admin-only actions; verify cross-lab isolation in UI
+
+---
+
+## PR 11 — Frontend domain API client
+> 🟡 Medium · ⚡ Medium · Replace flat `api-client.js` with namespaced domain modules.
+
+- [ ] Reorganise `api-client.js` into domain modules: `api.crm`, `api.jobs`, `api.finance`, `api.inventory` — no raw `fetch()` outside the API client except download/upload
+- [ ] Generate TypeScript types from the OpenAPI schema at `/api/docs/` using `openapi-typescript`; wire into the domain client so API shape mismatches surface at build time
+
+---
+
+## PR 12 — API versioning
+> 🟡 Medium · ✅ Easy · Add now, before the dashboard endpoint is built — retrofit later costs much more.
+
+- [ ] Prefix all app-scoped routes with `/api/v1/` in `config/urls.py` and per-app `urls.py`; keep existing unversioned root aliases as deprecated backward-compat routes with a comment
+
+---
+
+## PR 13 — CI image caching and OpenAPI snapshot
+> ⚪ Low · ⚡ Medium
+
+- [ ] Configure `docker buildx` with `--cache-from`/`--cache-to` (local or registry cache) so `lint`, `backend-tests`, and `frontend-check` share image layers instead of each rebuilding from scratch
+- [ ] Add a CI step that generates the OpenAPI schema (`manage.py generateschema`) and diffs it against a committed `doc/openapi-baseline.yaml`; fail if the schema changed without an updated baseline
+
+---
+
+## PR 14 — Observability and structured logging
+> 🟡 Medium · ⚡ Medium · Required before any real production traffic.
+
+- [ ] Add `django-structlog` (or `python-json-logger`) to emit JSON log lines with request ID, user, lab, and duration on every request
+- [ ] Add a `GET /api/health/` endpoint that checks DB connectivity and returns 200/503 — needed for load balancer and uptime monitoring
+- [ ] Document environment variables in `env/dev.env.example` with inline comments: required vs optional, default value, example
+
+---
+
+## PR 15 — Frontend component decomposition
+> 🟡 Medium · 💀 Hard · High-churn screens need splitting before they get larger.
+
+- [ ] Split job detail screen into: `JobHeader`, `JobStatusActions`, `JobItemsTable`, `JobAttachments`, `JobAuditLog` — each with its own data hook
+- [ ] Split invoice/finance screen into: `InvoiceForm`, `InvoiceLineItems`, `InvoiceStatusBadge`, `InvoiceActions`
+- [ ] Add consistent loading, empty, error, and permission-denied states across all list and detail screens
+
+---
+
+## PR 16 — Slovak localization
+> 🟡 Medium · 💀 Hard · Target market consistency — every user-facing string should be Slovak.
+
+- [ ] Audit and unify all UI labels, status names, validation error messages, date/currency formatting to Slovak conventions throughout all screens
+- [ ] Ensure invoice PDFs and CSV exports use Slovak column headers, date format (DD.MM.YYYY), and currency format (EUR with comma decimal)
+
+---
+
+## PR 17 — Product and UX improvements
+> ⚪ Low · ⚡ Medium · Quality-of-life for dental lab users.
+
+- [ ] Make invoice and job lifecycle states explicit in the UI — users should not need to infer the difference between `finished_factured`, `finished_unfactured`, `closed`, and `cancelled`
+- [ ] Add confirmation dialogs and audit trail display for destructive or financial actions (delete invoice, cancel job, status rollback)
+- [ ] Add role-specific dashboard views: technicians see their open jobs; admins see revenue summary and overdue invoices; superadmin sees cross-lab overview
+- [ ] Treat invoice PDFs and CSV job exports as first-class features with a defined format and download flow

--- a/backend/apps/core/auth.py
+++ b/backend/apps/core/auth.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone as datetime_timezone
 import pyotp
 from rest_framework import permissions
 from rest_framework.exceptions import AuthenticationFailed
-from rest_framework.throttling import ScopedRateThrottle
+from rest_framework.throttling import AnonRateThrottle, ScopedRateThrottle
 from rest_framework_simplejwt.serializers import (
     TokenObtainPairSerializer,
     TokenRefreshSerializer,
@@ -94,7 +94,7 @@ class MolarisTokenRefreshSerializer(TokenRefreshSerializer):
 class MolarisTokenObtainPairView(TokenObtainPairView):
     permission_classes = [permissions.AllowAny]
     serializer_class = MolarisTokenObtainPairSerializer
-    throttle_classes = [ScopedRateThrottle]
+    throttle_classes = [AnonRateThrottle, ScopedRateThrottle]
     throttle_scope = "login"
 
 

--- a/backend/apps/core/tests/test_auth.py
+++ b/backend/apps/core/tests/test_auth.py
@@ -218,6 +218,74 @@ class AuthLoginFlowTests(APITestCase):
         self.assertEqual(refresh.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
+class LogoutViewTests(APITestCase):
+    def setUp(self):
+        cache.clear()
+        self.lab = Lab.objects.create(name="Logout Lab")
+        self.user = User.objects.create_user(
+            username="logout_user",
+            password="pw123456",
+            email="logout@test.sk",
+            role="user",
+            lab=self.lab,
+        )
+
+    def _login(self):
+        resp = self.client.post(
+            "/api/token/",
+            {"username": self.user.username, "password": "pw123456"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        return resp.data["access"], resp.data["refresh"]
+
+    def test_logout_blacklists_refresh_token(self):
+        access, refresh = self._login()
+        resp = self.client.post(
+            "/api/core/auth/logout/",
+            {"refresh_token": refresh},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 204)
+        refresh_resp = self.client.post(
+            "/api/token/refresh/", {"refresh": refresh}, format="json"
+        )
+        self.assertEqual(refresh_resp.status_code, 401)
+
+    def test_logout_revokes_user_session(self):
+        _access, refresh = self._login()
+        jti = RefreshToken(refresh)["jti"]
+        self.assertTrue(UserSession.objects.filter(jti=jti, revoked=False).exists())
+        self.client.post(
+            "/api/core/auth/logout/",
+            {"refresh_token": refresh},
+            format="json",
+        )
+        self.assertTrue(UserSession.objects.filter(jti=jti, revoked=True).exists())
+
+    def test_logout_with_invalid_token_returns_204(self):
+        resp = self.client.post(
+            "/api/core/auth/logout/",
+            {"refresh_token": "this.is.garbage"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 204)
+
+    def test_logout_with_empty_body_returns_204(self):
+        resp = self.client.post("/api/core/auth/logout/", {}, format="json")
+        self.assertEqual(resp.status_code, 204)
+
+    def test_logout_works_without_access_token(self):
+        """Client with expired access token can still blacklist their refresh token."""
+        _access, refresh = self._login()
+        resp = self.client.post(
+            "/api/core/auth/logout/",
+            {"refresh_token": refresh},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 204)
+
+
 class AuthThrottleTests(APITestCase):
     def setUp(self):
         cache.clear()

--- a/backend/apps/core/urls.py
+++ b/backend/apps/core/urls.py
@@ -10,6 +10,7 @@ from .views import (
     LabApiKeyViewSet,
     LabRolePermissionViewSet,
     LabViewSet,
+    LogoutView,
     NotificationViewSet,
     PermissionsMatrixView,
     PermissionsView,
@@ -46,6 +47,7 @@ urlpatterns = [
         name="superadmin-metrics",
     ),
     path("auth/login/", SessionLoginView.as_view(), name="session-login"),
+    path("auth/logout/", LogoutView.as_view(), name="logout"),
     path(
         "dashboard/chart-data/",
         DashboardChartDataView.as_view(),

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -9,7 +9,7 @@ from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.response import Response
-from rest_framework.throttling import ScopedRateThrottle
+from rest_framework.throttling import AnonRateThrottle, ScopedRateThrottle
 from rest_framework.views import APIView
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -316,7 +316,7 @@ class PermissionsView(APIView):
 
 
 class LogoutView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.AllowAny]
 
     def post(self, request):
         refresh_token = request.data.get("refresh_token")
@@ -324,9 +324,7 @@ class LogoutView(APIView):
             try:
                 token = RefreshToken(refresh_token)
                 token.blacklist()
-                UserSession.objects.filter(jti=token["jti"], user=request.user).update(
-                    revoked=True
-                )
+                UserSession.objects.filter(jti=token["jti"]).update(revoked=True)
             except TokenError:
                 pass
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -1418,7 +1416,7 @@ class SessionLoginView(APIView):
     """JWT login that also persists a UserSession record."""
 
     permission_classes = [permissions.AllowAny]
-    throttle_classes = [ScopedRateThrottle]
+    throttle_classes = [AnonRateThrottle, ScopedRateThrottle]
     throttle_scope = "login"
 
     def post(self, request):

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -11,6 +11,7 @@ from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
+from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import RefreshToken
 
 from apps.finance.models import Subscription
@@ -312,6 +313,23 @@ class PermissionsView(APIView):
 
     def get(self, request):
         return Response(_role_permission_payload(request.user))
+
+
+class LogoutView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request):
+        refresh_token = request.data.get("refresh_token")
+        if refresh_token:
+            try:
+                token = RefreshToken(refresh_token)
+                token.blacklist()
+                UserSession.objects.filter(jti=token["jti"], user=request.user).update(
+                    revoked=True
+                )
+            except TokenError:
+                pass
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class SystemHealthView(APIView):
@@ -1291,6 +1309,7 @@ class UserViewSet(viewsets.ModelViewSet):
 
         user.set_password(data["new_password"])
         user.save(update_fields=["password"])
+        UserSession.objects.filter(user=user, revoked=False).update(revoked=True)
         _write_audit_log(
             request,
             action="user.password_changed",

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     # Third party
     "rest_framework",
+    "rest_framework_simplejwt.token_blacklist",
     "corsheaders",
     "drf_spectacular",
     "django_filters",
@@ -155,6 +156,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "config.pagination.OptionalPageNumberPagination",
     "DEFAULT_THROTTLE_CLASSES": ("rest_framework.throttling.ScopedRateThrottle",),
     "DEFAULT_THROTTLE_RATES": {
+        "anon": os.environ.get("THROTTLE_ANON_RATE", "20/min"),
         "login": os.environ.get("THROTTLE_LOGIN_RATE", "5/min"),
         "signup": os.environ.get("THROTTLE_SIGNUP_RATE", "5/min"),
         "invitation_accept": os.environ.get(

--- a/frontend/public/design/api-client.js
+++ b/frontend/public/design/api-client.js
@@ -245,6 +245,18 @@
   }
 
   function logout() {
+    const refresh = localStorage.getItem(refreshKey);
+    const access = localStorage.getItem(tokenKey);
+    if (refresh) {
+      fetch(`${API_BASE}/core/auth/logout/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(access ? { Authorization: `Bearer ${access}` } : {}),
+        },
+        body: JSON.stringify({ refresh_token: refresh }),
+      }).catch(() => {});
+    }
     localStorage.removeItem(tokenKey);
     localStorage.removeItem(refreshKey);
     localStorage.removeItem(userKey);


### PR DESCRIPTION
## Summary

- **Token blacklist**: Added `rest_framework_simplejwt.token_blacklist` to `INSTALLED_APPS`; applied migrations to create the blacklist tables
- **Logout endpoint**: New `POST /api/core/auth/logout/` accepts `refresh_token`, calls `token.blacklist()`, and revokes the `UserSession` record — frontend calls it fire-and-forget before clearing `localStorage`
- **Password change**: After a successful password change, all `UserSession` rows for the user are revoked, invalidating all existing refresh tokens across every device
- **Brute-force protection**: `AnonRateThrottle` (20/min) added alongside `ScopedRateThrottle` on `/api/token/` for IP-based protection; `"anon"` rate added to settings

## Test plan

- [x] `docker compose ... run --rm backend python manage.py test apps.core` — 305 tests pass
- [x] `black --check apps/core/views.py apps/core/auth.py apps/core/urls.py` — no reformats
- [x] `flake8 apps/core --max-line-length=120 --extend-ignore=E203,W503` — no errors
- [x] Manual: login, call `POST /api/core/auth/logout/` with the refresh token — subsequent `/api/token/refresh/` returns 401
- [x] Manual: change password — subsequent `/api/token/refresh/` with the old session JTI is denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)