### PR TITLE
feat(finance): service extraction — canonical invoice interfaces (PR 5)

### DIFF
--- a/backend/apps/core/services.py
+++ b/backend/apps/core/services.py
@@ -1,0 +1,23 @@
+"""
+Cross-cutting service utilities shared across Django apps.
+"""
+
+from .models import AuditLog
+
+
+def write_audit_log(*, actor, lab, action, entity_type, entity_id, description=None, metadata=None):
+    """
+    Create an AuditLog entry.
+
+    ``actor`` is the acting User (may be None for system actions).
+    ``entity_id`` is coerced to str.
+    """
+    AuditLog.objects.create(
+        actor=actor,
+        lab=lab,
+        action=action,
+        entity_type=entity_type,
+        entity_id=str(entity_id) if entity_id is not None else "",
+        description=description or f"{entity_type} {entity_id}: {action}",
+        metadata=metadata or {},
+    )

--- a/backend/apps/finance/invoice_service.py
+++ b/backend/apps/finance/invoice_service.py
@@ -12,7 +12,7 @@ from django.core.mail import EmailMessage
 from django.db import transaction
 from django.utils import timezone
 
-from apps.core.models import AuditLog
+from apps.core.services import write_audit_log
 from apps.jobs.models import Job
 
 from .calculations import calculate_invoice_amounts
@@ -49,12 +49,12 @@ def sync_jobs_for_invoice_status(invoice, new_status):
 
 def write_invoice_audit(actor, invoice, action, metadata=None, description=None):
     """Write an audit log entry for *invoice*. ``actor`` is the acting User (may be None)."""
-    AuditLog.objects.create(
+    write_audit_log(
         actor=actor,
         lab=invoice.lab,
         action=action,
         entity_type="invoice",
-        entity_id=str(invoice.id),
+        entity_id=invoice.id,
         description=description or f"Invoice {invoice.number}: {action}",
         metadata=metadata or {},
     )

--- a/backend/apps/finance/services.py
+++ b/backend/apps/finance/services.py
@@ -1,0 +1,80 @@
+"""
+Public service layer for finance business logic.
+
+This module defines the canonical interface for invoice operations.
+ViewSets validate HTTP input and delegate here; this layer owns
+all business rules (tenant checks, job validation, atomicity, audit).
+"""
+
+from decimal import Decimal
+
+from django.db import transaction
+from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
+
+from apps.core.access import is_superadmin
+from apps.crm.models import Clinic
+from apps.jobs.models import Job
+
+from . import invoice_service
+
+# ---------------------------------------------------------------------------
+# Invoice number
+# ---------------------------------------------------------------------------
+
+
+def next_invoice_number(lab):
+    """Return the next sequential invoice number for *lab* (must be called inside a transaction)."""
+    return invoice_service.generate_invoice_number(lab)
+
+
+# ---------------------------------------------------------------------------
+# Invoice creation
+# ---------------------------------------------------------------------------
+
+
+@transaction.atomic
+def create_invoice_from_jobs(*, user, clinic_id, job_ids, document_type="invoice", discount_percent=Decimal("0")):
+    """
+    Validate access, look up clinic and jobs, and create an invoice.
+
+    Raises ``NotFound`` if clinic or jobs are missing.
+    Raises ``PermissionDenied`` if *user* does not own the clinic's lab.
+    Raises ``ValidationError`` if jobs are inconsistent with the clinic.
+
+    Returns the created ``Invoice`` instance.
+    """
+    clinic = Clinic.objects.select_related("lab").filter(id=clinic_id).first()
+    if not clinic:
+        raise NotFound("Clinic not found")
+
+    if not is_superadmin(user) and clinic.lab_id != getattr(user, "lab_id", None):
+        raise PermissionDenied("Forbidden")
+
+    jobs = list(Job.objects.filter(id__in=job_ids).select_related("lab"))
+    if len(jobs) != len(set(job_ids)):
+        raise ValidationError({"detail": "One or more jobs not found"})
+
+    if any(job.lab_id != clinic.lab_id for job in jobs):
+        raise ValidationError({"detail": "All jobs must belong to the same clinic lab"})
+
+    return invoice_service.create_invoice(
+        actor=user,
+        clinic=clinic,
+        jobs=jobs,
+        document_type=document_type,
+        discount_percent=discount_percent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invoice status
+# ---------------------------------------------------------------------------
+
+
+def update_invoice_status(*, user, invoice, status):
+    """
+    Update *invoice* to *status*, sync linked job statuses, and write audit log.
+
+    Returns the updated ``Invoice`` instance.
+    """
+    return invoice_service.update_invoice_status(user, invoice, status)

--- a/backend/apps/finance/services.py
+++ b/backend/apps/finance/services.py
@@ -37,9 +37,9 @@ def create_invoice_from_jobs(*, user, clinic_id, job_ids, document_type="invoice
     """
     Validate access, look up clinic and jobs, and create an invoice.
 
-    Raises ``NotFound`` if clinic or jobs are missing.
+    Raises ``NotFound`` if clinic is missing.
     Raises ``PermissionDenied`` if *user* does not own the clinic's lab.
-    Raises ``ValidationError`` if jobs are inconsistent with the clinic.
+    Raises ``ValidationError`` if jobs are missing or inconsistent with the clinic.
 
     Returns the created ``Invoice`` instance.
     """
@@ -71,6 +71,7 @@ def create_invoice_from_jobs(*, user, clinic_id, job_ids, document_type="invoice
 # ---------------------------------------------------------------------------
 
 
+@transaction.atomic
 def update_invoice_status(*, user, invoice, status):
     """
     Update *invoice* to *status*, sync linked job statuses, and write audit log.

--- a/backend/apps/finance/tests/test_services.py
+++ b/backend/apps/finance/tests/test_services.py
@@ -1,0 +1,206 @@
+"""
+Unit tests for apps.finance.services — the public service interface.
+
+These tests exercise the business-logic layer (tenant checks, job validation,
+audit log routing) without going through the HTTP layer.
+"""
+
+from decimal import Decimal
+
+from django.test import TestCase
+from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
+
+from apps.core.models import AuditLog, Lab, User
+from apps.crm.models import Clinic, Patient
+from apps.finance import services as finance_services
+from apps.finance.models import Invoice, InvoiceItem
+from apps.jobs.models import Job
+
+
+class FinanceServiceSetupMixin:
+    def setUp(self):
+        self.lab = Lab.objects.create(
+            name="Service Lab",
+            invoice_prefix="SVC",
+            invoice_due_days=14,
+            vat_rate=Decimal("20"),
+        )
+        self.other_lab = Lab.objects.create(
+            name="Other Lab",
+            invoice_prefix="OTH",
+            invoice_due_days=14,
+            vat_rate=Decimal("20"),
+        )
+        self.admin = User.objects.create_user(
+            username="svc_admin",
+            email="svc_admin@test.sk",
+            password="pw",
+            role="admin",
+            lab=self.lab,
+        )
+        self.other_admin = User.objects.create_user(
+            username="other_admin",
+            email="other_admin@test.sk",
+            password="pw",
+            role="admin",
+            lab=self.other_lab,
+        )
+        self.superadmin = User.objects.create_user(
+            username="superadmin",
+            email="superadmin@test.sk",
+            password="pw",
+            role="superadmin",
+        )
+        self.clinic = Clinic.objects.create(lab=self.lab, name="Test Clinic")
+        self.patient = Patient.objects.create(
+            lab=self.lab,
+            first_name="Test",
+            last_name="Patient",
+            birth_number="900101/1234",
+        )
+        self.job = Job.objects.create(
+            lab=self.lab,
+            patient=self.patient,
+            clinic=self.clinic,
+            status="completed",
+            price="100.00",
+            description="Test work",
+        )
+
+
+# ---------------------------------------------------------------------------
+# next_invoice_number
+# ---------------------------------------------------------------------------
+
+
+class NextInvoiceNumberTests(FinanceServiceSetupMixin, TestCase):
+    def test_returns_string_with_lab_prefix(self):
+        number = finance_services.next_invoice_number(self.lab)
+        self.assertTrue(number.startswith("SVC-"), number)
+
+    def test_sequential_calls_return_different_numbers(self):
+        n1 = finance_services.next_invoice_number(self.lab)
+        n2 = finance_services.next_invoice_number(self.lab)
+        self.assertNotEqual(n1, n2)
+
+
+# ---------------------------------------------------------------------------
+# create_invoice_from_jobs
+# ---------------------------------------------------------------------------
+
+
+class CreateInvoiceFromJobsTests(FinanceServiceSetupMixin, TestCase):
+    def _call(self, **kwargs):
+        defaults = dict(
+            user=self.admin,
+            clinic_id=self.clinic.id,
+            job_ids=[self.job.id],
+            document_type="invoice",
+            discount_percent=Decimal("0"),
+        )
+        defaults.update(kwargs)
+        return finance_services.create_invoice_from_jobs(**defaults)
+
+    def test_happy_path_creates_invoice(self):
+        invoice = self._call()
+        self.assertIsInstance(invoice, Invoice)
+        self.assertEqual(invoice.clinic, self.clinic)
+        self.assertEqual(invoice.lab, self.lab)
+
+    def test_clinic_not_found_raises_not_found(self):
+        with self.assertRaises(NotFound):
+            self._call(clinic_id=99999)
+
+    def test_wrong_lab_user_raises_permission_denied(self):
+        with self.assertRaises(PermissionDenied):
+            self._call(user=self.other_admin)
+
+    def test_superadmin_can_create_for_any_lab(self):
+        invoice = self._call(user=self.superadmin)
+        self.assertIsInstance(invoice, Invoice)
+
+    def test_missing_job_raises_validation_error(self):
+        with self.assertRaises(ValidationError):
+            self._call(job_ids=[self.job.id, 99999])
+
+    def test_job_from_different_lab_raises_validation_error(self):
+        other_clinic = Clinic.objects.create(lab=self.other_lab, name="Other Clinic")
+        other_patient = Patient.objects.create(
+            lab=self.other_lab,
+            first_name="X",
+            last_name="Y",
+            birth_number="800101/0001",
+        )
+        other_job = Job.objects.create(
+            lab=self.other_lab,
+            patient=other_patient,
+            clinic=other_clinic,
+            status="completed",
+            price="50.00",
+        )
+        with self.assertRaises(ValidationError):
+            self._call(job_ids=[self.job.id, other_job.id])
+
+    def test_marks_jobs_finished_factured(self):
+        self._call()
+        self.job.refresh_from_db()
+        self.assertEqual(self.job.status, "finished_factured")
+
+    def test_calculates_total_amount(self):
+        invoice = self._call()
+        self.assertGreater(invoice.total_amount, Decimal("0"))
+
+
+# ---------------------------------------------------------------------------
+# update_invoice_status
+# ---------------------------------------------------------------------------
+
+
+class UpdateInvoiceStatusTests(FinanceServiceSetupMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.invoice = Invoice.objects.create(
+            lab=self.lab,
+            clinic=self.clinic,
+            number="SVC-2026-0001",
+            status="issued",
+            total_amount=Decimal("120.00"),
+        )
+        InvoiceItem.objects.create(
+            invoice=self.invoice,
+            job=self.job,
+            description="Work",
+            quantity=1,
+            unit_price=Decimal("120.00"),
+            line_total=Decimal("120.00"),
+        )
+
+    def test_changes_status(self):
+        finance_services.update_invoice_status(user=self.admin, invoice=self.invoice, status="paid")
+        self.invoice.refresh_from_db()
+        self.assertEqual(self.invoice.status, "paid")
+
+    def test_sets_paid_at_on_paid_transition(self):
+        finance_services.update_invoice_status(user=self.admin, invoice=self.invoice, status="paid")
+        self.invoice.refresh_from_db()
+        self.assertIsNotNone(self.invoice.paid_at)
+
+    def test_writes_audit_log_via_core_services(self):
+        before = AuditLog.objects.count()
+        finance_services.update_invoice_status(user=self.admin, invoice=self.invoice, status="paid")
+        self.assertEqual(AuditLog.objects.count(), before + 1)
+        log = AuditLog.objects.latest("id")
+        self.assertEqual(log.action, "invoice.status_changed")
+        self.assertEqual(log.metadata["from_status"], "issued")
+        self.assertEqual(log.metadata["to_status"], "paid")
+        self.assertEqual(log.entity_type, "invoice")
+        self.assertEqual(log.actor, self.admin)
+
+    def test_syncs_linked_jobs(self):
+        finance_services.update_invoice_status(user=self.admin, invoice=self.invoice, status="paid")
+        self.job.refresh_from_db()
+        self.assertEqual(self.job.status, "closed")
+
+    def test_returns_updated_invoice(self):
+        result = finance_services.update_invoice_status(user=self.admin, invoice=self.invoice, status="cancelled")
+        self.assertEqual(result.status, "cancelled")

--- a/backend/apps/finance/views.py
+++ b/backend/apps/finance/views.py
@@ -30,10 +30,9 @@ from apps.core.access import (
     is_superadmin,
 )
 from apps.core.exports import limited_export_queryset
-from apps.crm.models import Clinic
-from apps.jobs.models import Job
 
 from . import invoice_service
+from . import services as finance_services
 from .calculations import calculate_invoice_amounts, reverse_invoice_subtotal
 from .models import Invoice, PriceList, Subscription
 from .serializers import (
@@ -177,53 +176,31 @@ class InvoiceViewSet(viewsets.ModelViewSet):
 
         return qs
 
-    @transaction.atomic
     def create(self, request, *args, **kwargs):
         payload = InvoiceCreateSerializer(data=request.data)
         payload.is_valid(raise_exception=True)
         data = payload.validated_data
 
-        clinic = Clinic.objects.filter(id=data["clinic_id"]).first()
-        if not clinic:
-            return Response({"detail": "Clinic not found"}, status=status.HTTP_404_NOT_FOUND)
-
-        user = request.user
-        if not is_superadmin(user) and clinic.lab_id != getattr(user, "lab_id", None):
-            raise PermissionDenied("Forbidden")
-
-        jobs = list(Job.objects.filter(id__in=data["job_ids"]).select_related("lab"))
-        if len(jobs) != len(set(data["job_ids"])):
-            return Response(
-                {"detail": "One or more jobs not found"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        clinic_lab_jobs = [job for job in jobs if job.lab_id == clinic.lab_id]
-        if len(clinic_lab_jobs) != len(jobs):
-            return Response(
-                {"detail": "All jobs must belong to the same clinic lab"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        invoice = invoice_service.create_invoice(
-            actor=user,
-            clinic=clinic,
-            jobs=jobs,
+        invoice = finance_services.create_invoice_from_jobs(
+            user=request.user,
+            clinic_id=data["clinic_id"],
+            job_ids=data["job_ids"],
             document_type=data.get("document_type", "invoice"),
             discount_percent=data.get("discount_percent", Decimal("0")),
         )
-        out = InvoiceSerializer(invoice, context={"request": request})
-        return Response(out.data, status=status.HTTP_201_CREATED)
+        return Response(InvoiceSerializer(invoice, context={"request": request}).data, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["put"], url_path="status")
-    @transaction.atomic
     def update_status(self, request, pk=None):
         invoice = self.get_object()
         payload = InvoiceStatusUpdateSerializer(data=request.data)
         payload.is_valid(raise_exception=True)
-        new_status = payload.validated_data["status"]
 
-        invoice = invoice_service.update_invoice_status(request.user, invoice, new_status)
+        invoice = finance_services.update_invoice_status(
+            user=request.user,
+            invoice=invoice,
+            status=payload.validated_data["status"],
+        )
         return Response(InvoiceSerializer(invoice, context={"request": request}).data)
 
     @action(detail=True, methods=["get"], url_path="qr")


### PR DESCRIPTION
## Summary

- Adds `apps/core/services.py` with `write_audit_log()` as the single canonical audit write path; `invoice_service.write_invoice_audit` now delegates to it
- Adds `apps/finance/services.py` with the interfaces from the PR-5 spec: `create_invoice_from_jobs(*, user, clinic_id, job_ids, document_type, discount_percent)`, `next_invoice_number(lab)`, `update_invoice_status(*, user, invoice, status)`
- `InvoiceViewSet.create()` and `update_status()` simplified to HTTP input validation + serializer response only — all business logic (tenant checks, clinic/job lookup, atomicity) lives in the service
- `finance_services.update_invoice_status` delegates to `invoice_service.update_invoice_status` (no duplicate body) so the audit chain is: `finance_services` → `invoice_service` → `write_invoice_audit` → `core.services.write_audit_log`

## Test plan

- [ ] `apps/finance/tests/test_services.py` — 15 new tests covering `create_invoice_from_jobs` (clinic not found, permission denied, wrong lab jobs, happy path), `update_invoice_status` (status change, paid_at stamp, audit log, job sync), `next_invoice_number`
- [ ] All 360 existing backend tests still pass
- [ ] `ruff check` clean (one pre-existing `seed_users.py` warning unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)