### PR TITLE
feat(jobs): service extraction — public jobs service API (PR 6)

### DIFF
--- a/backend/apps/finance/invoice_service.py
+++ b/backend/apps/finance/invoice_service.py
@@ -13,7 +13,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from apps.core.services import write_audit_log
-from apps.jobs.models import Job
+from apps.jobs import services as jobs_services
 
 from .calculations import calculate_invoice_amounts
 from .models import Invoice, InvoiceItem, InvoiceSequence, PriceList
@@ -35,16 +35,13 @@ def generate_invoice_number(lab):
 
 def sync_jobs_for_invoice_status(invoice, new_status):
     """Sync the statuses of jobs linked to *invoice* when invoice status changes."""
-    job_ids = (
+    job_ids = list(
         InvoiceItem.objects.filter(invoice=invoice, job_id__isnull=False).values_list("job_id", flat=True).distinct()
     )
-    jobs = Job.objects.filter(id__in=job_ids)
-    if new_status == "paid":
-        jobs.update(status="closed")
-    elif new_status == "issued":
-        jobs.update(status="finished_factured")
-    elif new_status == "cancelled":
-        jobs.update(status="finished_unfactured")
+    if new_status == "cancelled":
+        jobs_services.mark_jobs_invoice_cancelled(job_ids)
+    else:
+        jobs_services.mark_jobs_invoiced(job_ids, invoice_status=new_status)
 
 
 def write_invoice_audit(actor, invoice, action, metadata=None, description=None):

--- a/backend/apps/jobs/services.py
+++ b/backend/apps/jobs/services.py
@@ -1,0 +1,59 @@
+"""
+Public service API for the jobs domain.
+
+This module is the canonical entry point for cross-domain callers (e.g. finance).
+All job state mutations should go through these functions rather than touching
+Job.objects directly from outside this app.
+"""
+
+from apps.jobs import job_service
+from apps.jobs.models import Job
+
+# Re-export so callers that previously used job_service can migrate incrementally.
+# The signature uses keyword-only ``user`` to match the rest of the service layer.
+
+INVOICE_STATUS_TO_JOB_STATUS = {
+    "paid": "closed",
+    "issued": "finished_factured",
+    "cancelled": "finished_unfactured",
+}
+
+
+def transition_job_status(*, user, job, new_status, note=None):
+    """
+    Transition *job* to *new_status* on behalf of *user*.
+
+    Delegates to ``job_service.transition_job_status`` which handles
+    validation, timeline recording, audit logging, and lab-admin notifications.
+
+    Returns the updated job.
+    Raises ``ValidationError`` if the transition is not allowed.
+    """
+    return job_service.transition_job_status(user, job, new_status, note)
+
+
+def mark_jobs_invoiced(job_ids, *, invoice_status):
+    """
+    Bulk-update the status of jobs in *job_ids* to reflect *invoice_status*.
+
+    Mapping:
+        ``issued``    → ``finished_factured``
+        ``paid``      → ``closed``
+        ``cancelled`` → ``finished_unfactured``
+
+    Unknown invoice statuses are silently ignored (no jobs updated).
+    """
+    new_job_status = INVOICE_STATUS_TO_JOB_STATUS.get(invoice_status)
+    if new_job_status is None:
+        return
+    Job.objects.filter(id__in=job_ids).update(status=new_job_status)
+
+
+def mark_jobs_invoice_cancelled(job_ids):
+    """
+    Reset the status of jobs in *job_ids* to ``finished_unfactured``.
+
+    Called when an invoice that covered these jobs is deleted/cancelled so
+    the jobs are no longer considered invoiced.
+    """
+    Job.objects.filter(id__in=job_ids).update(status="finished_unfactured")

--- a/backend/apps/jobs/tests/test_services.py
+++ b/backend/apps/jobs/tests/test_services.py
@@ -38,29 +38,21 @@ class JobServicesSetupMixin:
 
 class TransitionJobStatusTests(JobServicesSetupMixin, TestCase):
     def test_transitions_valid_status_via_keyword_args(self):
-        job = job_services.transition_job_status(
-            user=self.user, job=self.job, new_status="in_progress"
-        )
+        job = job_services.transition_job_status(user=self.user, job=self.job, new_status="in_progress")
         self.assertEqual(job.status, "in_progress")
 
     def test_raises_for_invalid_transition(self):
         with self.assertRaises(ValidationError):
-            job_services.transition_job_status(
-                user=self.user, job=self.job, new_status="completed"
-            )
+            job_services.transition_job_status(user=self.user, job=self.job, new_status="completed")
 
     def test_noop_when_already_at_target(self):
-        job = job_services.transition_job_status(
-            user=self.user, job=self.job, new_status="new"
-        )
+        job = job_services.transition_job_status(user=self.user, job=self.job, new_status="new")
         self.assertEqual(job.status, "new")
 
     def test_note_is_forwarded(self):
         from apps.jobs.models import JobTimelineEvent
 
-        job_services.transition_job_status(
-            user=self.user, job=self.job, new_status="in_progress", note="Custom note"
-        )
+        job_services.transition_job_status(user=self.user, job=self.job, new_status="in_progress", note="Custom note")
         event = JobTimelineEvent.objects.filter(job=self.job, event="status_changed").first()
         self.assertIsNotNone(event)
         self.assertEqual(event.note, "Custom note")
@@ -68,9 +60,7 @@ class TransitionJobStatusTests(JobServicesSetupMixin, TestCase):
 
 class MarkJobsInvoicedTests(JobServicesSetupMixin, TestCase):
     def _make_job(self, status="completed"):
-        return Job.objects.create(
-            lab=self.lab, patient=self.patient, clinic=self.clinic, status=status
-        )
+        return Job.objects.create(lab=self.lab, patient=self.patient, clinic=self.clinic, status=status)
 
     def test_paid_closes_jobs(self):
         j1, j2 = self._make_job(), self._make_job()

--- a/backend/apps/jobs/tests/test_services.py
+++ b/backend/apps/jobs/tests/test_services.py
@@ -1,0 +1,118 @@
+"""
+Unit tests for apps.jobs.services — the public cross-domain service API.
+"""
+
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+
+from apps.core.models import Lab, User
+from apps.crm.models import Clinic, Patient
+from apps.jobs import services as job_services
+from apps.jobs.models import Job
+
+
+class JobServicesSetupMixin:
+    def setUp(self):
+        self.lab = Lab.objects.create(name="Services Test Lab")
+        self.user = User.objects.create_user(
+            username="svc_user",
+            email="svc_user@test.sk",
+            password="pw",
+            role="admin",
+            lab=self.lab,
+        )
+        self.clinic = Clinic.objects.create(lab=self.lab, name="Clinic")
+        self.patient = Patient.objects.create(
+            lab=self.lab,
+            first_name="Jan",
+            last_name="Novak",
+            birth_number="900101/1234",
+        )
+        self.job = Job.objects.create(
+            lab=self.lab,
+            patient=self.patient,
+            clinic=self.clinic,
+            status="new",
+        )
+
+
+class TransitionJobStatusTests(JobServicesSetupMixin, TestCase):
+    def test_transitions_valid_status_via_keyword_args(self):
+        job = job_services.transition_job_status(
+            user=self.user, job=self.job, new_status="in_progress"
+        )
+        self.assertEqual(job.status, "in_progress")
+
+    def test_raises_for_invalid_transition(self):
+        with self.assertRaises(ValidationError):
+            job_services.transition_job_status(
+                user=self.user, job=self.job, new_status="completed"
+            )
+
+    def test_noop_when_already_at_target(self):
+        job = job_services.transition_job_status(
+            user=self.user, job=self.job, new_status="new"
+        )
+        self.assertEqual(job.status, "new")
+
+    def test_note_is_forwarded(self):
+        from apps.jobs.models import JobTimelineEvent
+
+        job_services.transition_job_status(
+            user=self.user, job=self.job, new_status="in_progress", note="Custom note"
+        )
+        event = JobTimelineEvent.objects.filter(job=self.job, event="status_changed").first()
+        self.assertIsNotNone(event)
+        self.assertEqual(event.note, "Custom note")
+
+
+class MarkJobsInvoicedTests(JobServicesSetupMixin, TestCase):
+    def _make_job(self, status="completed"):
+        return Job.objects.create(
+            lab=self.lab, patient=self.patient, clinic=self.clinic, status=status
+        )
+
+    def test_paid_closes_jobs(self):
+        j1, j2 = self._make_job(), self._make_job()
+        job_services.mark_jobs_invoiced([j1.id, j2.id], invoice_status="paid")
+        j1.refresh_from_db()
+        j2.refresh_from_db()
+        self.assertEqual(j1.status, "closed")
+        self.assertEqual(j2.status, "closed")
+
+    def test_issued_marks_factured(self):
+        j = self._make_job()
+        job_services.mark_jobs_invoiced([j.id], invoice_status="issued")
+        j.refresh_from_db()
+        self.assertEqual(j.status, "finished_factured")
+
+    def test_cancelled_marks_unfactured(self):
+        j = self._make_job()
+        job_services.mark_jobs_invoiced([j.id], invoice_status="cancelled")
+        j.refresh_from_db()
+        self.assertEqual(j.status, "finished_unfactured")
+
+    def test_unknown_invoice_status_is_noop(self):
+        j = self._make_job()
+        job_services.mark_jobs_invoiced([j.id], invoice_status="draft")
+        j.refresh_from_db()
+        self.assertEqual(j.status, "completed")
+
+    def test_empty_job_ids_is_noop(self):
+        job_services.mark_jobs_invoiced([], invoice_status="paid")
+
+
+class MarkJobsInvoiceCancelledTests(JobServicesSetupMixin, TestCase):
+    def test_resets_jobs_to_unfactured(self):
+        j = Job.objects.create(
+            lab=self.lab,
+            patient=self.patient,
+            clinic=self.clinic,
+            status="finished_factured",
+        )
+        job_services.mark_jobs_invoice_cancelled([j.id])
+        j.refresh_from_db()
+        self.assertEqual(j.status, "finished_unfactured")
+
+    def test_empty_list_is_noop(self):
+        job_services.mark_jobs_invoice_cancelled([])

--- a/backend/apps/jobs/views.py
+++ b/backend/apps/jobs/views.py
@@ -25,6 +25,7 @@ from apps.crm.models import Clinic, Patient
 from apps.crm.serializers import PatientSerializer
 
 from . import job_service
+from . import services as job_services
 from .models import (
     CalendarEvent,
     Job,
@@ -233,7 +234,7 @@ class JobViewSet(TenantScopedQuerysetMixin, viewsets.ModelViewSet):
 
         new_status = serializer.validated_data["status"]
         note = serializer.validated_data.get("note")
-        job = job_service.transition_job_status(request.user, job, new_status, note)
+        job = job_services.transition_job_status(user=request.user, job=job, new_status=new_status, note=note)
         return Response(self.get_serializer(job).data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=["get"], url_path="work_order")


### PR DESCRIPTION
## Summary

- Creates `apps/jobs/services.py` as the canonical public API for cross-domain job mutations, with three functions: `transition_job_status(*, user, job, new_status, note=None)`, `mark_jobs_invoiced(job_ids, *, invoice_status)`, and `mark_jobs_invoice_cancelled(job_ids)`
- Finance no longer writes to `Job.objects` directly: `sync_jobs_for_invoice_status` in `invoice_service.py` now delegates to the new jobs service functions
- `JobViewSet.transition_status` routes through `services.transition_job_status` (keyword-only signature) as the new canonical call site
- Adds 11 unit tests covering all three service functions (valid/invalid transitions, all invoice status mappings, edge cases)

## Test plan

- [x] `apps.jobs.tests.test_services` — 11 new tests, all pass
- [x] Full test suite — 604 tests pass, zero regressions
- [x] `ruff check` — no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)