### PR TITLE
feat(security): JWT httpOnly cookie auth (PR 8)

### DIFF
--- a/backend/apps/core/auth.py
+++ b/backend/apps/core/auth.py
@@ -118,7 +118,8 @@ class MolarisTokenRefreshView(TokenRefreshView):
     def post(self, request, *args, **kwargs):
         # Prefer refresh token from cookie; fall back to request body for backward compat.
         cookie_refresh = request.COOKIES.get(_REFRESH_COOKIE)
-        data = dict(request.data) if request.data else {}
+        # Use .copy() when available (QueryDict) to preserve scalar values; fall back to dict().
+        data = request.data.copy() if hasattr(request.data, "copy") else dict(request.data or {})
         if cookie_refresh and not data.get("refresh"):
             data["refresh"] = cookie_refresh
 

--- a/backend/apps/core/auth.py
+++ b/backend/apps/core/auth.py
@@ -2,9 +2,12 @@ from datetime import datetime
 from datetime import timezone as datetime_timezone
 
 import pyotp
+from django.middleware.csrf import get_token as csrf_get_token
 from rest_framework import permissions
 from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle, ScopedRateThrottle
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 from rest_framework_simplejwt.serializers import (
     TokenObtainPairSerializer,
     TokenRefreshSerializer,
@@ -12,6 +15,7 @@ from rest_framework_simplejwt.serializers import (
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
+from .cookie_auth import _REFRESH_COOKIE, set_jwt_cookies
 from .models import UserSession
 
 
@@ -98,7 +102,38 @@ class MolarisTokenObtainPairView(TokenObtainPairView):
     throttle_classes = [AnonRateThrottle, ScopedRateThrottle]
     throttle_scope = "login"
 
+    def post(self, request, *args, **kwargs):
+        response = super().post(request, *args, **kwargs)
+        if response.status_code == 200:
+            set_jwt_cookies(response, response.data["access"], response.data["refresh"])
+            # Seed the CSRF cookie so the frontend can make authenticated mutations immediately.
+            csrf_get_token(request)
+        return response
+
 
 class MolarisTokenRefreshView(TokenRefreshView):
     permission_classes = [permissions.AllowAny]
     serializer_class = MolarisTokenRefreshSerializer
+
+    def post(self, request, *args, **kwargs):
+        # Prefer refresh token from cookie; fall back to request body for backward compat.
+        cookie_refresh = request.COOKIES.get(_REFRESH_COOKIE)
+        data = dict(request.data) if request.data else {}
+        if cookie_refresh and not data.get("refresh"):
+            data["refresh"] = cookie_refresh
+
+        serializer = self.get_serializer(data=data)
+        try:
+            serializer.is_valid(raise_exception=True)
+        except TokenError as exc:
+            raise InvalidToken(exc.args[0])
+
+        response = Response(serializer.validated_data)
+        set_jwt_cookies(
+            response,
+            serializer.validated_data["access"],
+            # When ROTATE_REFRESH_TOKENS=True SimpleJWT issues a new refresh token;
+            # fall back to the incoming cookie so the cookie always stays current.
+            serializer.validated_data.get("refresh") or data.get("refresh", ""),
+        )
+        return response

--- a/backend/apps/core/cookie_auth.py
+++ b/backend/apps/core/cookie_auth.py
@@ -8,14 +8,17 @@ rest_framework_simplejwt.views at module level here would create a circular impo
 rest_framework_simplejwt.views itself imports rest_framework.views → rest_framework.schemas.
 
 Rules for this file:
-  - Only import from django.* and rest_framework.exceptions (both are fully loaded before
+  - Only import from stdlib, django.*, and rest_framework.exceptions (all fully loaded before
     DEFAULT_AUTHENTICATION_CLASSES is first accessed).
   - Import rest_framework_simplejwt.authentication lazily (inside methods).
 """
 
+from datetime import timedelta
+
 from django.conf import settings
 from django.middleware.csrf import CsrfViewMiddleware
 from rest_framework import exceptions
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 
 _ACCESS_COOKIE = "molaris_access"
 _REFRESH_COOKIE = "molaris_refresh"
@@ -29,17 +32,26 @@ class _CSRFCheck(CsrfViewMiddleware):
 
 
 def _cookie_params():
-    secure = getattr(settings, "JWT_COOKIE_SECURE", not settings.DEBUG)
+    secure = getattr(settings, "JWT_COOKIE_SECURE", True)
     samesite = getattr(settings, "JWT_COOKIE_SAMESITE", "Strict")
     return secure, samesite
 
 
+def _jwt_max_ages():
+    """Derive cookie lifetimes from SIMPLE_JWT so they stay in sync with token expiry."""
+    simple_jwt = getattr(settings, "SIMPLE_JWT", {})
+    access = simple_jwt.get("ACCESS_TOKEN_LIFETIME", timedelta(minutes=15))
+    refresh = simple_jwt.get("REFRESH_TOKEN_LIFETIME", timedelta(days=7))
+    return int(access.total_seconds()), int(refresh.total_seconds())
+
+
 def set_jwt_cookies(response, access, refresh):
     secure, samesite = _cookie_params()
+    access_max_age, refresh_max_age = _jwt_max_ages()
     response.set_cookie(
         _ACCESS_COOKIE,
         str(access),
-        max_age=15 * 60,
+        max_age=access_max_age,
         httponly=True,
         secure=secure,
         samesite=samesite,
@@ -48,7 +60,7 @@ def set_jwt_cookies(response, access, refresh):
     response.set_cookie(
         _REFRESH_COOKIE,
         str(refresh),
-        max_age=7 * 24 * 3600,
+        max_age=refresh_max_age,
         httponly=True,
         secure=secure,
         samesite=samesite,
@@ -74,10 +86,10 @@ class JWTCookieAuthentication:
         if raw_token is None:
             return self._jwt().authenticate(request)
 
+        jwt = self._jwt()
         try:
-            jwt = self._jwt()
             validated_token = jwt.get_validated_token(raw_token)
-        except Exception:
+        except (TokenError, InvalidToken):
             return None
 
         self._enforce_csrf(request)

--- a/backend/apps/core/cookie_auth.py
+++ b/backend/apps/core/cookie_auth.py
@@ -1,0 +1,94 @@
+"""
+httpOnly JWT cookie authentication.
+
+This module is intentionally isolated: it is referenced in DEFAULT_AUTHENTICATION_CLASSES,
+which is evaluated by rest_framework.schemas at import time (triggered via
+rest_framework.views → rest_framework.schemas.__init__).  Importing anything from
+rest_framework_simplejwt.views at module level here would create a circular import because
+rest_framework_simplejwt.views itself imports rest_framework.views → rest_framework.schemas.
+
+Rules for this file:
+  - Only import from django.* and rest_framework.exceptions (both are fully loaded before
+    DEFAULT_AUTHENTICATION_CLASSES is first accessed).
+  - Import rest_framework_simplejwt.authentication lazily (inside methods).
+"""
+
+from django.conf import settings
+from django.middleware.csrf import CsrfViewMiddleware
+from rest_framework import exceptions
+
+_ACCESS_COOKIE = "molaris_access"
+_REFRESH_COOKIE = "molaris_refresh"
+
+
+class _CSRFCheck(CsrfViewMiddleware):
+    """Returns the failure reason string instead of an HttpResponse so callers can raise."""
+
+    def _reject(self, request, reason):
+        return reason
+
+
+def _cookie_params():
+    secure = getattr(settings, "JWT_COOKIE_SECURE", not settings.DEBUG)
+    samesite = getattr(settings, "JWT_COOKIE_SAMESITE", "Strict")
+    return secure, samesite
+
+
+def set_jwt_cookies(response, access, refresh):
+    secure, samesite = _cookie_params()
+    response.set_cookie(
+        _ACCESS_COOKIE,
+        str(access),
+        max_age=15 * 60,
+        httponly=True,
+        secure=secure,
+        samesite=samesite,
+        path="/",
+    )
+    response.set_cookie(
+        _REFRESH_COOKIE,
+        str(refresh),
+        max_age=7 * 24 * 3600,
+        httponly=True,
+        secure=secure,
+        samesite=samesite,
+        path="/",
+    )
+
+
+def clear_jwt_cookies(response):
+    response.delete_cookie(_ACCESS_COOKIE, path="/")
+    response.delete_cookie(_REFRESH_COOKIE, path="/")
+
+
+class JWTCookieAuthentication:
+    """Authenticates via the httpOnly access cookie; enforces CSRF on cookie-authenticated requests."""
+
+    def _jwt(self):
+        from rest_framework_simplejwt.authentication import JWTAuthentication
+
+        return JWTAuthentication()
+
+    def authenticate(self, request):
+        raw_token = request.COOKIES.get(_ACCESS_COOKIE)
+        if raw_token is None:
+            return self._jwt().authenticate(request)
+
+        try:
+            jwt = self._jwt()
+            validated_token = jwt.get_validated_token(raw_token)
+        except Exception:
+            return None
+
+        self._enforce_csrf(request)
+        return jwt.get_user(validated_token), validated_token
+
+    def authenticate_header(self, request):
+        return 'Bearer realm="api"'
+
+    def _enforce_csrf(self, request):
+        checker = _CSRFCheck(get_response=lambda req: None)
+        checker.process_request(request)
+        reason = checker.process_view(request, None, (), {})
+        if reason:
+            raise exceptions.PermissionDenied(f"CSRF Failed: {reason}")

--- a/backend/apps/core/tests/test_auth.py
+++ b/backend/apps/core/tests/test_auth.py
@@ -442,3 +442,91 @@ class TwoFactorTests(APITestCase):
     def test_unauthenticated_denied(self):
         resp = self.client.get("/api/core/2fa/")
         self.assertEqual(resp.status_code, 401)
+
+
+class CookieAuthTests(APITestCase):
+    def setUp(self):
+        cache.clear()
+        self.lab = Lab.objects.create(name="Cookie Lab")
+        self.user = User.objects.create_user(
+            username="cookie_user",
+            password="pw123456",
+            email="cookie@test.sk",
+            role="user",
+            lab=self.lab,
+        )
+
+    def _login_cookie(self):
+        resp = self.client.post(
+            "/api/token/",
+            {"username": self.user.username, "password": "pw123456"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        return resp
+
+    def test_login_sets_httponly_access_cookie(self):
+        resp = self._login_cookie()
+        self.assertIn("molaris_access", resp.cookies)
+        self.assertTrue(resp.cookies["molaris_access"]["httponly"])
+
+    def test_login_sets_httponly_refresh_cookie(self):
+        resp = self._login_cookie()
+        self.assertIn("molaris_refresh", resp.cookies)
+        self.assertTrue(resp.cookies["molaris_refresh"]["httponly"])
+
+    def test_login_still_returns_tokens_in_body(self):
+        resp = self._login_cookie()
+        self.assertIn("access", resp.data)
+        self.assertIn("refresh", resp.data)
+
+    def test_cookie_authentication_grants_access(self):
+        login_resp = self._login_cookie()
+        access_token = login_resp.cookies["molaris_access"].value
+        self.client.cookies["molaris_access"] = access_token
+        resp = self.client.get("/api/core/users/me/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data["username"], self.user.username)
+
+    def test_refresh_via_cookie_sets_new_access_cookie(self):
+        login_resp = self._login_cookie()
+        self.client.cookies["molaris_refresh"] = login_resp.cookies["molaris_refresh"].value
+        resp = self.client.post("/api/token/refresh/", {}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("molaris_access", resp.cookies)
+
+    def test_refresh_still_accepts_body_token(self):
+        login_resp = self._login_cookie()
+        resp = self.client.post(
+            "/api/token/refresh/",
+            {"refresh": login_resp.data["refresh"]},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("access", resp.data)
+
+    def test_logout_via_cookie_clears_cookies(self):
+        login_resp = self._login_cookie()
+        self.client.cookies["molaris_refresh"] = login_resp.cookies["molaris_refresh"].value
+        resp = self.client.post("/api/core/auth/logout/", {}, format="json")
+        self.assertEqual(resp.status_code, 204)
+        # Django signals cookie deletion via Max-Age=0
+        self.assertIn("molaris_access", resp.cookies)
+        self.assertIn("molaris_refresh", resp.cookies)
+        self.assertEqual(resp.cookies["molaris_access"]["max-age"], 0)
+        self.assertEqual(resp.cookies["molaris_refresh"]["max-age"], 0)
+
+    def test_logout_via_cookie_blacklists_refresh_token(self):
+        login_resp = self._login_cookie()
+        refresh_raw = login_resp.data["refresh"]
+        self.client.cookies["molaris_refresh"] = login_resp.cookies["molaris_refresh"].value
+        self.client.post("/api/core/auth/logout/", {}, format="json")
+        # Refresh token should now be blacklisted
+        resp = self.client.post("/api/token/refresh/", {"refresh": refresh_raw}, format="json")
+        self.assertEqual(resp.status_code, 401)
+
+    def test_csrf_endpoint_seeds_csrf_cookie(self):
+        resp = self.client.get("/api/core/csrf/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("csrfToken", resp.data)
+        self.assertIn("csrftoken", resp.cookies)

--- a/backend/apps/core/urls.py
+++ b/backend/apps/core/urls.py
@@ -5,6 +5,7 @@ from rest_framework.routers import DefaultRouter
 # This is kept for backward compatibility and nested access (/api/core/users/, /api/core/labs/)
 from .views import (
     AuditLogViewSet,
+    CsrfView,
     DashboardChartDataView,
     GlobalSearchView,
     LabApiKeyViewSet,
@@ -46,6 +47,7 @@ urlpatterns = [
     ),
     path("auth/login/", SessionLoginView.as_view(), name="session-login"),
     path("auth/logout/", LogoutView.as_view(), name="logout"),
+    path("csrf/", CsrfView.as_view(), name="csrf"),
     path(
         "dashboard/chart-data/",
         DashboardChartDataView.as_view(),

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -20,6 +20,7 @@ from apps.jobs.models import CalendarEvent, Vacation
 from . import user_service
 from .access import assert_lab_write_allowed, is_admin_or_superadmin, is_superadmin
 from .auth import MolarisTokenObtainPairSerializer
+from .cookie_auth import _REFRESH_COOKIE, clear_jwt_cookies
 from .models import (
     AuditLog,
     Lab,
@@ -305,15 +306,30 @@ class LogoutView(APIView):
     permission_classes = [permissions.AllowAny]
 
     def post(self, request):
-        refresh_token = request.data.get("refresh_token")
-        if refresh_token:
+        # Accept refresh token from cookie (new) or request body (backward compat).
+        refresh_raw = request.COOKIES.get(_REFRESH_COOKIE) or request.data.get("refresh_token")
+        if refresh_raw:
             try:
-                token = RefreshToken(refresh_token)
+                token = RefreshToken(refresh_raw)
                 token.blacklist()
                 UserSession.objects.filter(jti=token["jti"]).update(revoked=True)
             except TokenError:
                 pass
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        response = Response(status=status.HTTP_204_NO_CONTENT)
+        clear_jwt_cookies(response)
+        return response
+
+
+class CsrfView(APIView):
+    """Seeds the csrftoken cookie so the frontend can make authenticated mutations."""
+
+    permission_classes = [permissions.AllowAny]
+    authentication_classes = []
+
+    def get(self, request):
+        from django.middleware.csrf import get_token
+
+        return Response({"csrfToken": get_token(request)})
 
 
 class SystemHealthView(APIView):

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -3,6 +3,7 @@ Django base settings — shared across all environments.
 """
 
 import os
+from datetime import timedelta
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -130,6 +131,8 @@ AUTH_USER_MODEL = "core.User"
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_AUTHENTICATION_CLASSES": (
+        # Cookie-based auth takes priority; header-based JWT kept for API clients / tests.
+        "apps.core.cookie_auth.JWTCookieAuthentication",
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ),
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
@@ -146,6 +149,15 @@ REST_FRAMEWORK = {
         "api_key_create": os.environ.get("THROTTLE_API_KEY_CREATE_RATE", "5/min"),
     },
 }
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=15),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
+}
+
+# httpOnly JWT cookie settings (used by apps.core.auth)
+JWT_COOKIE_SECURE = os.environ.get("JWT_COOKIE_SECURE", "0") == "1"
+JWT_COOKIE_SAMESITE = os.environ.get("JWT_COOKIE_SAMESITE", "Strict")
 
 SPECTACULAR_SETTINGS = {
     "TITLE": "Dental Lab API",

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -155,8 +155,9 @@ SIMPLE_JWT = {
     "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
 }
 
-# httpOnly JWT cookie settings (used by apps.core.auth)
-JWT_COOKIE_SECURE = os.environ.get("JWT_COOKIE_SECURE", "0") == "1"
+# httpOnly JWT cookie settings (used by apps.core.cookie_auth)
+# Default secure=True so production is safe if the env var is forgotten; dev.py overrides to False.
+JWT_COOKIE_SECURE = os.environ.get("JWT_COOKIE_SECURE", "1") == "1"
 JWT_COOKIE_SAMESITE = os.environ.get("JWT_COOKIE_SAMESITE", "Strict")
 
 SPECTACULAR_SETTINGS = {

--- a/backend/config/settings/dev.py
+++ b/backend/config/settings/dev.py
@@ -7,3 +7,16 @@ from .base import *  # noqa: F401,F403
 DEBUG = True
 SECRET_KEY = "django-insecure-dev-key-change-me"
 ALLOWED_HOSTS = ["*"]
+
+# Cookies over plain HTTP in dev
+JWT_COOKIE_SECURE = False
+
+# Allow the Vite dev server origins to pass Django's CSRF Referer check on HTTPS (no-op on HTTP
+# but kept so the setting is ready when the dev stack moves to HTTPS).
+CSRF_TRUSTED_ORIGINS = [
+    "http://localhost:5173",
+    "http://localhost:5280",
+    "http://localhost:8810",
+    "http://127.0.0.1:5173",
+    "http://127.0.0.1:5280",
+]

--- a/frontend/src/api/api-client.js
+++ b/frontend/src/api/api-client.js
@@ -277,10 +277,7 @@ import { createUseWorkspace } from '../hooks/useWorkspace.js';
     fetch(`${API_BASE}/core/auth/logout/`, {
       method: 'POST',
       credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRFToken': getCsrfToken(),
-      },
+      headers: { 'X-CSRFToken': getCsrfToken() },
     }).catch(() => {});
     localStorage.removeItem(userKey);
   }

--- a/frontend/src/api/api-client.js
+++ b/frontend/src/api/api-client.js
@@ -8,9 +8,12 @@ import { createUseWorkspace } from '../hooks/useWorkspace.js';
     ? rawBase.replace(/\/$/, '')
     : `${rawBase.replace(/\/$/, '')}/api`;
 
-  const tokenKey = 'molaris.access';
-  const refreshKey = 'molaris.refresh';
   const userKey = 'molaris.user';
+
+  function getCsrfToken() {
+    const match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
 
   const readJson = async (response) => {
     const text = await response.text();
@@ -18,17 +21,42 @@ import { createUseWorkspace } from '../hooks/useWorkspace.js';
     try { return JSON.parse(text); } catch { return text; }
   };
 
+  let _refreshInFlight = null;
+  async function _silentRefresh() {
+    if (_refreshInFlight) return _refreshInFlight;
+    _refreshInFlight = fetch(`${API_BASE}/token/refresh/`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'X-CSRFToken': getCsrfToken() },
+    })
+      .then((resp) => resp.ok)
+      .catch(() => false)
+      .finally(() => { _refreshInFlight = null; });
+    return _refreshInFlight;
+  }
+
   async function request(path, options = {}) {
-    const access = localStorage.getItem(tokenKey);
+    const method = (options.method || 'GET').toUpperCase();
+    const csrfSafe = /^(GET|HEAD|OPTIONS|TRACE)$/.test(method);
     const headers = {
       Accept: 'application/json',
       ...(options.body ? { 'Content-Type': 'application/json' } : {}),
-      ...(access ? { Authorization: `Bearer ${access}` } : {}),
+      ...(!csrfSafe ? { 'X-CSRFToken': getCsrfToken() } : {}),
       ...(options.headers || {}),
     };
-    const response = await fetch(`${API_BASE}${path}`, { ...options, headers });
+    const response = await fetch(`${API_BASE}${path}`, {
+      ...options,
+      headers,
+      credentials: 'include',
+    });
     const data = await readJson(response);
     if (!response.ok) {
+      if (response.status === 401 && !options._retried && !path.startsWith('/token/')) {
+        const refreshed = await _silentRefresh();
+        if (refreshed) {
+          return request(path, { ...options, _retried: true });
+        }
+      }
       if (response.status === 401) {
         logout();
         window.dispatchEvent(new CustomEvent('molaris-auth-expired'));
@@ -78,8 +106,7 @@ import { createUseWorkspace } from '../hooks/useWorkspace.js';
       }
       throw error;
     }
-    localStorage.setItem(tokenKey, token.access);
-    localStorage.setItem(refreshKey, token.refresh);
+    // Tokens are now stored as httpOnly cookies by the server.
     const me = await request('/core/users/me/');
     const name = [me.first_name, me.last_name].filter(Boolean).join(' ') || me.nickname || me.username;
     const user = {
@@ -230,9 +257,8 @@ import { createUseWorkspace } from '../hooks/useWorkspace.js';
   }
 
   async function downloadInvoicePdf(id, filename) {
-    const access = localStorage.getItem(tokenKey);
     const response = await fetch(authUrl(`/invoices/${id}/pdf/`), {
-      headers: access ? { Authorization: `Bearer ${access}` } : {},
+      credentials: 'include',
     });
     if (!response.ok) throw new Error('PDF download failed');
     const blob = await response.blob();
@@ -247,30 +273,24 @@ import { createUseWorkspace } from '../hooks/useWorkspace.js';
   }
 
   function logout() {
-    const refresh = localStorage.getItem(refreshKey);
-    const access = localStorage.getItem(tokenKey);
-    if (refresh) {
-      fetch(`${API_BASE}/core/auth/logout/`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(access ? { Authorization: `Bearer ${access}` } : {}),
-        },
-        body: JSON.stringify({ refresh_token: refresh }),
-      }).catch(() => {});
-    }
-    localStorage.removeItem(tokenKey);
-    localStorage.removeItem(refreshKey);
+    // Fire-and-forget: server blacklists the refresh cookie and clears both cookies.
+    fetch(`${API_BASE}/core/auth/logout/`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfToken(),
+      },
+    }).catch(() => {});
     localStorage.removeItem(userKey);
   }
 
   function savedUser() {
-    if (!isAuthenticated()) return null;
     try { return JSON.parse(localStorage.getItem(userKey) || 'null'); } catch { return null; }
   }
 
   function isAuthenticated() {
-    return !!localStorage.getItem(tokenKey);
+    return !!localStorage.getItem(userKey);
   }
 
   const fmtDate = (value) => value ? new Date(value).toLocaleDateString('sk-SK') : '—';
@@ -454,7 +474,7 @@ import { createUseWorkspace } from '../hooks/useWorkspace.js';
     };
   }
 
-  const useWorkspace = createUseWorkspace({ loadWorkspace, tokenKey });
+  const useWorkspace = createUseWorkspace({ loadWorkspace, tokenKey: userKey });
 
   window.MolarisAPI = {
     API_BASE,


### PR DESCRIPTION
## Summary

- **Backend**: New `cookie_auth.py` module adds `JWTCookieAuthentication` — reads access token from `molaris_access` httpOnly cookie, enforces CSRF via Django's `CsrfViewMiddleware` pattern. Isolated into its own file to avoid a circular import: `DEFAULT_AUTHENTICATION_CLASSES` is read by `rest_framework.schemas` at import time, and `rest_framework_simplejwt.views` (imported in `auth.py`) transitively imports `rest_framework.views → rest_framework.schemas`, creating a deadlock if the auth class lived in `auth.py`.
- **Login** sets `molaris_access` (15 min, httpOnly, SameSite=Strict) and `molaris_refresh` (7 days) cookies and seeds the `csrftoken` cookie in the same response so the frontend can immediately make authenticated mutations.
- **Token refresh** reads the cookie first, falls back to body for backward compat; also updates the refresh cookie to correctly support `ROTATE_REFRESH_TOKENS=True`.
- **Logout** reads refresh from cookie or body, blacklists it, and clears both cookies server-side.
- **`GET /api/core/csrf/`** endpoint seeds the `csrftoken` cookie on page reload when the user already has a session.
- **Frontend**: removes all `localStorage` access/refresh token reads and writes; adds `getCsrfToken()` + `X-CSRFToken` header on all mutations; silent token refresh on 401 with a shared in-flight promise (prevents N concurrent 401s from each firing their own refresh POST); `isAuthenticated()` now checks the cached user object.

## Architecture note

`JWTCookieAuthentication` is in `apps/core/cookie_auth.py`, not `auth.py`. The class imports `JWTAuthentication` lazily (inside `_jwt()`) to break the circular import. `auth.py` is not referenced in `DEFAULT_AUTHENTICATION_CLASSES` so it can safely import `rest_framework_simplejwt.views` at module level.

## Security properties

- Access token: httpOnly, SameSite=Strict, 15-minute lifetime — not readable by JS, rotation-safe
- Refresh token: httpOnly, SameSite=Strict, 7-day lifetime
- CSRF enforced for all cookie-authenticated state-changing requests via `_enforce_csrf()`
- Bearer-header JWT auth preserved as fallback for API clients and tests (no CSRF required — no cookie means no CSRF surface)
- `CORS_ALLOW_CREDENTIALS = True` already set; `CSRF_TRUSTED_ORIGINS` added for localhost Vite ports

## Test plan

- [x] 40/40 backend auth tests pass (includes 9 new `CookieAuthTests`)
- [x] `ruff check` passes on all changed files
- [x] Frontend `eslint` — 0 errors (71 pre-existing warnings)
- [ ] Manual: login flow sets cookies visible in DevTools → Application → Cookies
- [ ] Manual: API calls include cookies (check Network tab, no Authorization header)
- [ ] Manual: logout clears cookies in browser
- [ ] Manual: page reload with valid session works without re-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)