### PR TITLE
test(e2e): Playwright smoke tests (PR 10)

### DIFF
--- a/frontend/e2e/auth.spec.js
+++ b/frontend/e2e/auth.spec.js
@@ -1,62 +1,87 @@
 // @ts-check
 import { test, expect } from '@playwright/test';
+import { loginAs, BASE } from './helpers.js';
 
 /**
- * Auth + navigation smoke tests.
+ * Auth smoke tests: login / logout / session expiry.
  *
  * Requires a running dev stack (docker compose up).
  * Run with: npm run test:e2e
  *
- * Uses the seeded credentials: admin / admin
+ * Seeded credentials: admin / admin  and  user / user
  */
 
-const BASE = process.env.E2E_BASE_URL || 'http://localhost:5173';
-
 test.describe('Login page', () => {
-  test('renders login form without crashing', async ({ page }) => {
+  test('renders login form', async ({ page }) => {
     await page.goto(BASE);
     await expect(page.locator('input[type="password"]')).toBeVisible();
+    await expect(page.locator('button[type="submit"]')).toBeVisible();
   });
 
-  test('shows error on invalid credentials', async ({ page }) => {
+  test('shows Slovak error on wrong credentials', async ({ page }) => {
     await page.goto(BASE);
-    await page.fill('input[type="text"], input[name="username"]', 'baduser');
-    await page.fill('input[type="password"]', 'badpass');
+    await page.fill('input[type="text"]', 'nobody');
+    await page.fill('input[type="password"]', 'wrongpass');
     await page.click('button[type="submit"]');
-    // Backend returns 401 — frontend should surface an error message.
-    await expect(page.locator('body')).toContainText(/.+/);
+    await expect(page.locator('body')).toContainText('Neplatné prihlasovacie údaje', { timeout: 8000 });
+  });
+
+  test('empty username shows client-side validation', async ({ page }) => {
+    await page.goto(BASE);
+    await page.fill('input[type="password"]', 'something');
+    await page.click('button[type="submit"]');
+    await expect(page.locator('body')).toContainText('Vyplňte všetky polia', { timeout: 4000 });
   });
 });
 
-test.describe('Authenticated navigation', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto(BASE);
-    await page.fill('input[type="text"], input[name="username"]', 'admin');
-    await page.fill('input[type="password"]', 'admin');
-    await page.click('button[type="submit"]');
-    // Wait for the app shell to appear after login.
-    await page.waitForTimeout(1500);
-  });
-
-  test('dashboard loads after login', async ({ page }) => {
-    // The main app content area should be visible.
-    await expect(page.locator('body')).not.toContainText('Login');
-  });
-
-  test('sidebar is present for admin user', async ({ page }) => {
-    // The sidebar nav should be rendered for authenticated admin users.
+test.describe('Successful login and app shell', () => {
+  test('admin login lands on dashboard with sidebar', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
     const nav = page.locator('nav, [role="navigation"]');
     await expect(nav.first()).toBeVisible();
+    await expect(page.locator('body')).toContainText('Práce');
   });
 
-  test('unauthenticated direct navigation redirects to login', async ({ page }) => {
-    // Clear auth state and try to access the app.
+  test('logout button is visible after login', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+    await expect(page.locator('[title="Odhlásiť sa"]')).toBeVisible();
+  });
+});
+
+test.describe('Logout', () => {
+  test('clicking logout returns to login form', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+    await page.click('[title="Odhlásiť sa"]');
+    await expect(page.locator('input[type="password"]')).toBeVisible({ timeout: 8000 });
+  });
+});
+
+test.describe('Session expiry', () => {
+  test('auth-expired event shows login form without page reload', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
     await page.evaluate(() => {
-      localStorage.removeItem('accessToken');
-      localStorage.removeItem('refreshToken');
-      localStorage.removeItem('savedUser');
+      window.dispatchEvent(new CustomEvent('molaris-auth-expired'));
+    });
+    await expect(page.locator('input[type="password"]')).toBeVisible({ timeout: 6000 });
+  });
+
+  test('clearing saved user and reloading shows login form', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+    // Auth tokens are httpOnly cookies (not cleared from JS), but the app shell
+    // gates rendering on the presence of 'molaris.user' in localStorage.
+    // Clearing it simulates the user never being recognised.
+    await page.evaluate(() => {
+      localStorage.removeItem('molaris.user');
     });
     await page.reload();
-    await expect(page.locator('input[type="password"]')).toBeVisible();
+    await expect(page.locator('input[type="password"]')).toBeVisible({ timeout: 8000 });
+  });
+
+  test('navigating to app URL with no saved user shows login form', async ({ page }) => {
+    // Fresh page with no login — the app must not render the shell.
+    // (Cookies may still exist from a previous test; what matters is that the
+    // React app reads 'molaris.user' to hydrate state, not the cookie directly.)
+    await page.goto(BASE);
+    await expect(page.locator('input[type="password"]')).toBeVisible({ timeout: 8000 });
   });
 });

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -1,0 +1,57 @@
+// @ts-check
+import { expect } from '@playwright/test';
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:5173';
+
+export async function loginAs(page, username, password) {
+  await page.goto(BASE);
+  await page.fill('input[type="text"]', username);
+  await page.fill('input[type="password"]', password);
+  await page.click('button[type="submit"]');
+  await page.waitForSelector('[title="Odhlásiť sa"]', { timeout: 12000 });
+}
+
+/**
+ * Poll until window.__MOLARIS_WORKSPACE is populated with the required
+ * collections (patients, clinics, priceList) and return the workspace object.
+ * Resolves null after ~8 seconds if data never arrives.
+ */
+export async function waitForWorkspace(page, extraKeys = []) {
+  return page.evaluate(async (keys) => {
+    const required = ['patients', 'clinics', 'priceList', ...keys];
+    return new Promise((resolve) => {
+      let tries = 0;
+      const poll = setInterval(() => {
+        const w = window.__MOLARIS_WORKSPACE;
+        if (w && required.every((k) => w[k] && w[k].length)) {
+          clearInterval(poll);
+          resolve(w);
+        }
+        if (++tries > 40) { clearInterval(poll); resolve(null); }
+      }, 200);
+    });
+  }, extraKeys);
+}
+
+/**
+ * Wait until __MOLARIS_WORKSPACE is non-null (i.e. the async reload
+ * triggered by a mutation has completed and data is available again).
+ * Uses the same polling approach as waitForWorkspace.
+ */
+export async function waitForWorkspaceReload(page) {
+  return page.evaluate(async () => {
+    return new Promise((resolve) => {
+      let tries = 0;
+      const poll = setInterval(() => {
+        const w = window.__MOLARIS_WORKSPACE;
+        if (w && w.invoices !== undefined) {
+          clearInterval(poll);
+          resolve(w);
+        }
+        if (++tries > 50) { clearInterval(poll); resolve(null); }
+      }, 200);
+    });
+  });
+}
+
+export { expect, BASE };

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -5,7 +5,7 @@ const BASE = process.env.E2E_BASE_URL || 'http://localhost:5173';
 
 export async function loginAs(page, username, password) {
   await page.goto(BASE);
-  await page.fill('input[type="text"]', username);
+  await page.locator('input[type="text"]').first().fill(username);
   await page.fill('input[type="password"]', password);
   await page.click('button[type="submit"]');
   await page.waitForSelector('[title="Odhlásiť sa"]', { timeout: 12000 });

--- a/frontend/e2e/invoice-flow.spec.js
+++ b/frontend/e2e/invoice-flow.spec.js
@@ -48,7 +48,8 @@ test.describe('Invoice lifecycle', () => {
     await page.waitForTimeout(500);
 
     // 3. Fill the invoice form — clinic select + job IDs text field
-    await page.locator('select[name="clinic_id"]').selectOption({ index: 0 });
+    // Select the specific clinic by its ID to avoid picking the placeholder (value="")
+    await page.locator('select[name="clinic_id"]').selectOption(String(setupResult.clinicId));
     await page.fill('input[name="job_ids"]', String(setupResult.jobId));
     await page.getByText('Vytvoriť faktúru').click();
 

--- a/frontend/e2e/invoice-flow.spec.js
+++ b/frontend/e2e/invoice-flow.spec.js
@@ -1,0 +1,132 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { loginAs, waitForWorkspace, waitForWorkspaceReload } from './helpers.js';
+
+/**
+ * Smoke test: Invoice creation from jobs → status change to paid → job syncs to closed.
+ *
+ * Job is brought to "completed" state via the transition-status API before the
+ * invoice is created through the UI drawer.  Status changes (issued → paid) are
+ * applied via the MolarisAPI client so we are not blocked by missing UI actions for
+ * the "paid" state.  We then verify the job record in the Jobs list reflects the
+ * backend-calculated closed status.
+ *
+ * Requires a running dev stack (docker compose up + seed data).
+ */
+
+test.describe('Invoice lifecycle', () => {
+  test('create invoice from a completed job, mark paid, verify job closes', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+
+    const ws = await waitForWorkspace(page);
+    expect(ws).toBeTruthy();
+
+    // 1. Create a job and transition it to 'completed'
+    const setupResult = await page.evaluate(async (workspace) => {
+      const job = await window.MolarisAPI.createJob({
+        patient: workspace.patients[0].id,
+        clinic: workspace.clinics[0].id,
+        doctor: workspace.doctors && workspace.doctors.length ? workspace.doctors[0].id : null,
+        start_date: new Date().toISOString().slice(0, 10),
+        due_date: new Date(Date.now() + 3 * 86400000).toISOString().slice(0, 10),
+        priority: 'normal',
+        description: 'Invoice smoke-test job',
+        items: [{ price_list_code: workspace.priceList[0].code, tooth: '36', quantity: 1 }],
+      });
+      // Status machine: new → in_progress → completed
+      await window.MolarisAPI.transitionJobStatus(job.id, 'in_progress');
+      await window.MolarisAPI.transitionJobStatus(job.id, 'completed');
+      return { jobId: job.id, clinicId: workspace.clinics[0].id };
+    }, ws);
+
+    expect(setupResult.jobId).toBeTruthy();
+
+    // 2. Navigate to Invoices and open the "New Invoice" drawer
+    await page.getByText('Faktúry').first().click();
+    await page.waitForTimeout(800);
+    await page.getByText('Nová faktúra').click();
+    await page.waitForTimeout(500);
+
+    // 3. Fill the invoice form — clinic select + job IDs text field
+    await page.locator('select[name="clinic_id"]').selectOption({ index: 0 });
+    await page.fill('input[name="job_ids"]', String(setupResult.jobId));
+    await page.getByText('Vytvoriť faktúru').click();
+
+    // 4. Wait for the workspace async reload triggered by createRecord()
+    //    (createRecord sets __MOLARIS_WORKSPACE = null, then fires a reload event;
+    //     a fixed timeout is not reliable — poll until invoices list is available)
+    const wsAfter = await waitForWorkspaceReload(page);
+    expect(wsAfter).toBeTruthy();
+
+    // InvoiceSerializer exposes the linked jobs under the 'related_jobs' key
+    const invoice = wsAfter.invoices && wsAfter.invoices.find((i) => {
+      const relJobs = i.raw && i.raw.related_jobs;
+      return Array.isArray(relJobs) && relJobs.some((j) => j.id === setupResult.jobId);
+    });
+    expect(invoice).toBeTruthy();
+
+    // 5. Mark invoice issued then paid via API
+    await page.evaluate(async (invoiceId) => {
+      await window.MolarisAPI.updateInvoiceStatus(invoiceId, 'issued');
+      await window.MolarisAPI.updateInvoiceStatus(invoiceId, 'paid');
+    }, invoice.id);
+
+    // 6. Navigate to Jobs and find the specific job row by ID, then check its status
+    await page.getByText('Práce').first().click();
+    await page.waitForTimeout(1500);
+
+    const jobIdStr = String(setupResult.jobId);
+    await expect(page.locator('body')).toContainText(jobIdStr, { timeout: 8000 });
+
+    // Scope the status check to the row that contains the test job's ID so we
+    // don't accidentally pass because another job on-screen carries a closed status.
+    const jobRow = page.locator(`tr, [data-row], li`).filter({ hasText: jobIdStr }).first();
+    const closedStatuses = ['closed', 'finished_factured', 'Uzavretá', 'Fakturovaná'];
+    const rowText = await jobRow.innerText();
+    const hasClosedStatus = closedStatuses.some((s) => rowText.includes(s));
+    expect(hasClosedStatus).toBe(true);
+  });
+
+  test('invoice detail drawer opens and shows invoice number', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+
+    const ws = await waitForWorkspace(page);
+    expect(ws).toBeTruthy();
+
+    // Create a completed job and invoice entirely via API
+    const invoiceId = await page.evaluate(async (workspace) => {
+      const job = await window.MolarisAPI.createJob({
+        patient: workspace.patients[0].id,
+        clinic: workspace.clinics[0].id,
+        start_date: new Date().toISOString().slice(0, 10),
+        due_date: new Date(Date.now() + 5 * 86400000).toISOString().slice(0, 10),
+        priority: 'normal',
+        description: 'Invoice drawer smoke test',
+        items: [{ price_list_code: workspace.priceList[0].code, tooth: '46', quantity: 1 }],
+      });
+      await window.MolarisAPI.transitionJobStatus(job.id, 'in_progress');
+      await window.MolarisAPI.transitionJobStatus(job.id, 'completed');
+
+      const inv = await window.MolarisAPI.createRecord('/invoices/', {
+        clinic_id: workspace.clinics[0].id,
+        job_ids: [job.id],
+      });
+      return inv.id;
+    }, ws);
+
+    expect(invoiceId).toBeTruthy();
+
+    // Navigate to Invoices
+    await page.getByText('Faktúry').first().click();
+    await page.waitForTimeout(1000);
+
+    // Open the invoice detail via the eye icon button (aria-label or title = "Detail")
+    const eyeBtn = page.locator('[aria-label="Detail"], [title="Detail"]').first();
+    await eyeBtn.click();
+    await page.waitForTimeout(500);
+
+    // Drawer must show the "Zatvoriť" and "Odoslať klinike" action buttons
+    await expect(page.locator('body')).toContainText('Zatvoriť', { timeout: 5000 });
+    await expect(page.locator('body')).toContainText('Odoslať klinike', { timeout: 5000 });
+  });
+});

--- a/frontend/e2e/patient-job-flow.spec.js
+++ b/frontend/e2e/patient-job-flow.spec.js
@@ -25,10 +25,15 @@ test.describe('Patient creation via UI', () => {
     await page.getByText('Pridať pacienta').click();
     await page.waitForTimeout(400);
 
-    // Each test run uses a unique timestamp suffix to avoid the per-lab
-    // unique constraint on birth_number.
+    // Unique, syntactically valid rodné číslo (YYMMDD/XXXX) — using today's
+    // date as prefix so the format passes backend validation, and a
+    // timestamp-derived 4-digit serial so each run produces a distinct value.
     const suffix = Date.now();
-    const birthNum = `${suffix}`.slice(-10).padStart(10, '9');
+    const now = new Date();
+    const yy = String(now.getFullYear()).slice(-2);
+    const mm = String(now.getMonth() + 1).padStart(2, '0');
+    const dd = String(now.getDate()).padStart(2, '0');
+    const birthNum = `${yy}${mm}${dd}/${String(suffix).slice(-4).padStart(4, '0')}`;
 
     await page.fill('input[name="first_name"]', `TestMeno${suffix}`);
     await page.fill('input[name="last_name"]', `TestPriezvisko${suffix}`);

--- a/frontend/e2e/patient-job-flow.spec.js
+++ b/frontend/e2e/patient-job-flow.spec.js
@@ -1,0 +1,117 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { loginAs, waitForWorkspace } from './helpers.js';
+
+/**
+ * Smoke test: Create patient → create job → assign technician.
+ *
+ * Patient is created through the UI drawer.
+ * Job is created via the MolarisAPI JS client (the NewJob modal requires
+ * a dental-chart interaction that is impractical to drive end-to-end).
+ * Technician assignment is verified via job create + job detail screen.
+ *
+ * Requires a running dev stack (docker compose up + seed data).
+ */
+
+test.describe('Patient creation via UI', () => {
+  test('admin can create a patient through the drawer', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+
+    // Navigate to Patients via sidebar
+    await page.getByText('Pacienti').first().click();
+    await page.waitForTimeout(800);
+
+    // Open the create-patient drawer
+    await page.getByText('Pridať pacienta').click();
+    await page.waitForTimeout(400);
+
+    // Each test run uses a unique timestamp suffix to avoid the per-lab
+    // unique constraint on birth_number.
+    const suffix = Date.now();
+    const birthNum = `${suffix}`.slice(-10).padStart(10, '9');
+
+    await page.fill('input[name="first_name"]', `TestMeno${suffix}`);
+    await page.fill('input[name="last_name"]', `TestPriezvisko${suffix}`);
+    await page.fill('input[name="birth_number"]', birthNum);
+
+    // Submit
+    await page.getByText('Vytvoriť pacienta').click();
+
+    // Drawer closes and the new patient row appears in the list
+    await expect(page.locator('body')).toContainText(`TestMeno${suffix}`, { timeout: 8000 });
+  });
+});
+
+test.describe('Job creation and technician assignment', () => {
+  test('job created via API appears in the Jobs list', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+
+    const ws = await waitForWorkspace(page);
+    expect(ws).toBeTruthy();
+
+    const jobId = await page.evaluate(async (workspace) => {
+      const job = await window.MolarisAPI.createJob({
+        patient: workspace.patients[0].id,
+        clinic: workspace.clinics[0].id,
+        doctor: workspace.doctors && workspace.doctors.length ? workspace.doctors[0].id : null,
+        technician: workspace.technicians && workspace.technicians.length ? workspace.technicians[0].id : null,
+        start_date: new Date().toISOString().slice(0, 10),
+        due_date: new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10),
+        priority: 'normal',
+        description: 'Playwright smoke-test job',
+        items: [{ price_list_code: workspace.priceList[0].code, tooth: '26', quantity: 1 }],
+      });
+      return job.id;
+    }, ws);
+
+    expect(jobId).toBeTruthy();
+
+    // Navigate to Jobs list and verify the new job appears
+    await page.getByText('Práce').first().click();
+    await page.waitForTimeout(1000);
+    await expect(page.locator('body')).toContainText(String(jobId), { timeout: 8000 });
+  });
+
+  test('technician assignment is reflected in job detail', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+
+    const ws = await waitForWorkspace(page, ['technicians']);
+    expect(ws).toBeTruthy();
+    expect(ws.technicians.length).toBeGreaterThan(0);
+
+    const result = await page.evaluate(async (workspace) => {
+      const tech = workspace.technicians[0];
+      const job = await window.MolarisAPI.createJob({
+        patient: workspace.patients[0].id,
+        clinic: workspace.clinics[0].id,
+        doctor: workspace.doctors && workspace.doctors.length ? workspace.doctors[0].id : null,
+        technician: tech.id,
+        start_date: new Date().toISOString().slice(0, 10),
+        due_date: new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10),
+        priority: 'normal',
+        description: 'Playwright tech-assignment smoke test',
+        items: [{ price_list_code: workspace.priceList[0].code, tooth: '11', quantity: 1 }],
+      });
+      return {
+        jobId: job.id,
+        techFirst: tech.first || tech.first_name || '',
+        techLast: tech.last || tech.last_name || '',
+      };
+    }, ws);
+
+    expect(result).toBeTruthy();
+    expect(result.jobId).toBeTruthy();
+
+    // Navigate to Jobs and open the job detail
+    await page.getByText('Práce').first().click();
+    await page.waitForTimeout(1000);
+    const jobRow = page.locator(`text=${result.jobId}`).first();
+    await expect(jobRow).toBeVisible({ timeout: 8000 });
+    await jobRow.click();
+    await page.waitForTimeout(800);
+
+    // Job detail must show the assigned technician's name
+    const techName = [result.techFirst, result.techLast].filter(Boolean).join(' ');
+    await expect(page.locator('body')).toContainText(techName, { timeout: 6000 });
+  });
+});

--- a/frontend/e2e/permissions.spec.js
+++ b/frontend/e2e/permissions.spec.js
@@ -64,8 +64,8 @@ test.describe('User role — restricted access', () => {
     // Not on the Permissions page — the role matrix should be absent
     await expect(page.getByText('Oprávnenia').first()).not.toBeVisible();
     // On the Dashboard — which always renders a time-of-day greeting:
-    // "Dobré ráno" / "Dobrý deň" / "Dobrý večer" / "Dobrý noc"
-    await expect(page.locator('body')).toContainText(/Dobr(ý|é)/, { timeout: 4000 });
+    // "Dobré ráno" / "Dobrý deň" / "Dobrý večer" / "Dobrú noc"
+    await expect(page.locator('body')).toContainText(/Dobr(ý|é|ú)/, { timeout: 4000 });
   });
 
   test('user does not see Faktúry in sidebar', async ({ page }) => {

--- a/frontend/e2e/permissions.spec.js
+++ b/frontend/e2e/permissions.spec.js
@@ -1,0 +1,128 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { loginAs } from './helpers.js';
+
+/**
+ * Smoke tests: role-based access control in the UI.
+ *
+ *  · Non-admin (role=user) cannot reach admin-only pages — App.jsx
+ *    `normalizePageForRole` redirects them to dashboard.
+ *  · Admin sees the "Oprávnenia" sidebar item; user/technician do not.
+ *  · Cross-lab isolation: the seeded dataset contains only one lab, so a
+ *    full cross-lab UI test is not possible here.  Backend isolation is
+ *    covered by test_role_matrix.py.  The UI test only verifies that the
+ *    workspace returns jobs without leaking an unexpected lab id.
+ *
+ * Requires a running dev stack (docker compose up + seed data).
+ * Seeded credentials: admin / admin  and  user / user
+ */
+
+test.describe('Admin role — full access', () => {
+  test('sidebar shows Oprávnenia link for admin', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+    await expect(page.getByText('Oprávnenia')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('admin can navigate to Permissions page', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+    await page.getByText('Oprávnenia').click();
+    await page.waitForTimeout(600);
+    // The Permissions page renders role definitions and module matrix
+    await expect(page.locator('body')).toContainText('Administrátor', { timeout: 6000 });
+    await expect(page.locator('body')).toContainText('Používateľ');
+  });
+
+  test('admin sees Faktúry (Invoices) in sidebar', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+    await expect(page.getByText('Faktúry')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('admin sees Sklad (Inventory) in sidebar', async ({ page }) => {
+    await loginAs(page, 'admin', 'admin');
+    await expect(page.getByText('Sklad')).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe('User role — restricted access', () => {
+  test('sidebar does not show Oprávnenia for user role', async ({ page }) => {
+    await loginAs(page, 'user', 'user');
+    await expect(page.getByText('Oprávnenia')).not.toBeVisible({ timeout: 4000 });
+  });
+
+  test('user navigating to permissions via event lands on dashboard, not Permissions page', async ({ page }) => {
+    await loginAs(page, 'user', 'user');
+
+    // Dispatch a visual-navigate event to "permissions" — the app normalises it
+    // to "dashboard" via normalizePageForRole.
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent('molaris-visual-navigate', { detail: { page: 'permissions' } }));
+    });
+    await page.waitForTimeout(600);
+
+    // Still authenticated
+    await expect(page.locator('[title="Odhlásiť sa"]')).toBeVisible();
+    // Not on the Permissions page — the role matrix should be absent
+    await expect(page.getByText('Oprávnenia').first()).not.toBeVisible();
+    // On the Dashboard — which always renders a time-of-day greeting:
+    // "Dobré ráno" / "Dobrý deň" / "Dobrý večer" / "Dobrý noc"
+    await expect(page.locator('body')).toContainText(/Dobr(ý|é)/, { timeout: 4000 });
+  });
+
+  test('user does not see Faktúry in sidebar', async ({ page }) => {
+    await loginAs(page, 'user', 'user');
+    await expect(page.getByText('Faktúry')).not.toBeVisible({ timeout: 4000 });
+  });
+
+  test('user does not see Sklad in sidebar', async ({ page }) => {
+    await loginAs(page, 'user', 'user');
+    await expect(page.getByText('Sklad')).not.toBeVisible({ timeout: 4000 });
+  });
+
+  test('user can view the Jobs list (shared access)', async ({ page }) => {
+    await loginAs(page, 'user', 'user');
+    await page.getByText('Práce').first().click();
+    await page.waitForTimeout(800);
+    await expect(page.locator('[title="Odhlásiť sa"]')).toBeVisible();
+  });
+
+  test('user can view the Patients list (shared access)', async ({ page }) => {
+    await loginAs(page, 'user', 'user');
+    await page.getByText('Pacienti').first().click();
+    await page.waitForTimeout(800);
+    await expect(page.locator('[title="Odhlásiť sa"]')).toBeVisible();
+  });
+});
+
+test.describe('Cross-lab isolation in UI', () => {
+  test('user workspace jobs all carry the expected lab id', async ({ page }) => {
+    await loginAs(page, 'user', 'user');
+
+    // Retrieve the lab id from the saved user record
+    const userLab = await page.evaluate(() => {
+      const u = JSON.parse(localStorage.getItem('molaris.user') || '{}');
+      return u && u.lab ? u.lab.id : null;
+    });
+    expect(userLab).toBeTruthy();
+
+    await page.getByText('Práce').first().click();
+    await page.waitForTimeout(1200);
+
+    // Every job in the workspace must carry the user's lab id (or no lab field
+    // at all — the backend only returns same-lab data so the field may be absent
+    // from the normalised object).
+    // NOTE: the seeded dataset contains only one lab, so this test cannot
+    // detect isolation bugs between two distinct labs.  Full cross-lab
+    // isolation is verified server-side in test_role_matrix.py.
+    const mismatch = await page.evaluate((expectedLabId) => {
+      const ws = window.__MOLARIS_WORKSPACE;
+      if (!ws || !ws.jobs) return 0;
+      return ws.jobs.filter((j) => {
+        const raw = j.raw || j;
+        // Only flag jobs that explicitly carry a lab id that differs from ours
+        return raw.lab && raw.lab !== expectedLabId;
+      }).length;
+    }, userLab);
+
+    expect(mismatch).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- 25 Playwright tests across 4 spec files covering the 4 PR-10 journeys
- Shared helpers extracted to `e2e/helpers.js` (loginAs, waitForWorkspace, waitForWorkspaceReload)
- Updated `auth.spec.js` to fix stale localStorage keys from pre-cookie-auth era

## Tests added

| File | Describes |
|---|---|
| `e2e/auth.spec.js` | Login/logout/session expiry (9 tests) |
| `e2e/patient-job-flow.spec.js` | Patient UI creation, job API + detail (3 tests) |
| `e2e/invoice-flow.spec.js` | Invoice lifecycle, status → job sync (2 tests) |
| `e2e/permissions.spec.js` | Admin vs user role access, redirect, cross-lab (11 tests) |

## Key design choices

- **Job creation** uses `window.MolarisAPI.createJob()` via `page.evaluate()` — the NewJob modal's 4-step dental-chart flow is impractical to drive end-to-end
- **Invoice lookup** uses `i.raw.related_jobs` (matching the `InvoiceSerializer` field name, not `i.raw.jobs`)
- **Workspace readiness** uses polling instead of fixed `waitForTimeout()` to avoid CI flakiness after mutations reset `__MOLARIS_WORKSPACE = null`
- **Birth number** uses a timestamp-derived suffix per run to avoid the per-lab unique constraint failing on the second run
- **Closed-status check** is scoped to the specific job row, not the entire page body
- **Cross-lab note**: the seeded dataset has one lab; full isolation is covered server-side by `test_role_matrix.py`

## Test plan

- [ ] `docker compose up` with seed data
- [ ] `cd frontend && npm run test:e2e` — all 25 tests should pass
- [ ] Re-run `test:e2e` a second time to confirm no unique-constraint failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)