### PR TITLE
feat(api): add /api/v1/ versioned routes (PR 12)

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -20,7 +20,8 @@ from apps.finance.views import InvoiceViewSet
 from apps.inventory.views import WarehouseItemViewSet
 from apps.jobs.views import CalendarEventViewSet, CalendarView, VacationViewSet
 
-# Root-level router for commonly accessed endpoints
+# Root-level router — flat shortcuts kept as deprecated backward-compat aliases.
+# New clients should use the app-scoped /api/v1/ routes instead.
 root_router = DefaultRouter()
 root_router.register(r"invoices", InvoiceViewSet)
 root_router.register(r"users", UserViewSet)
@@ -32,25 +33,32 @@ root_router.register(r"vacations", VacationViewSet)
 root_router.register(r"calendar-events", CalendarEventViewSet)
 root_router.register(r"warehouse", WarehouseItemViewSet)
 
+# Versioned app-scoped patterns — shared between /api/v1/ and the deprecated /api/ prefix.
+# Defined once to ensure both prefixes stay in sync; adding a new app URL here
+# automatically exposes it under both the canonical v1 path and the legacy path.
+_versioned_patterns = [
+    path("core/", include("apps.core.urls")),
+    path("crm/", include("apps.crm.urls")),
+    path("jobs/", include("apps.jobs.urls")),
+    path("finance/", include("apps.finance.urls")),
+    path("inventory/", include("apps.inventory.urls")),
+    path("dashboard/stats/", DashboardStatsView.as_view(), name="dashboard-stats"),
+    path("search/", GlobalSearchView.as_view(), name="global-search"),
+    path("permissions/", PermissionsView.as_view(), name="permissions"),
+    path("system-health/", SystemHealthView.as_view(), name="system-health"),
+    path("calendar/", CalendarView.as_view(), name="calendar"),
+]
+
 urlpatterns = [
     path("admin/", admin.site.urls),
-    # Root API endpoints
-    path("api/", include(root_router.urls)),
-    path("api/dashboard/stats/", DashboardStatsView.as_view(), name="dashboard-stats"),
-    path("api/search/", GlobalSearchView.as_view(), name="global-search-root"),
-    path("api/permissions/", PermissionsView.as_view(), name="permissions-root"),
-    path("api/system-health/", SystemHealthView.as_view(), name="system-health-root"),
-    path("api/calendar/", CalendarView.as_view(), name="calendar"),
-    # Nested app routes
-    path("api/core/", include("apps.core.urls")),
-    path("api/crm/", include("apps.crm.urls")),
-    path("api/jobs/", include("apps.jobs.urls")),
-    path("api/finance/", include("apps.finance.urls")),
-    path("api/inventory/", include("apps.inventory.urls")),
-    # Auth
+    # ------------------------------------------------------------------
+    # Auth — not versioned; used by all API versions
+    # ------------------------------------------------------------------
     path("api/token/", MolarisTokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", MolarisTokenRefreshView.as_view(), name="token_refresh"),
-    # Swagger/Schema
+    # ------------------------------------------------------------------
+    # Swagger / OpenAPI schema — not versioned
+    # ------------------------------------------------------------------
     path(
         "api/schema/",
         SpectacularAPIView.as_view(permission_classes=[IsAdminOrSuperadminPermission]),
@@ -64,4 +72,14 @@ urlpatterns = [
         ),
         name="swagger-ui",
     ),
+    # ------------------------------------------------------------------
+    # v1 — canonical versioned routes
+    # ------------------------------------------------------------------
+    path("api/v1/", include(_versioned_patterns)),
+    # ------------------------------------------------------------------
+    # DEPRECATED — unversioned aliases kept for backward compatibility.
+    # New clients should use /api/v1/... equivalents above.
+    # ------------------------------------------------------------------
+    path("api/", include(_versioned_patterns)),
+    path("api/", include(root_router.urls)),
 ]

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -73,13 +73,15 @@ urlpatterns = [
         name="swagger-ui",
     ),
     # ------------------------------------------------------------------
-    # v1 — canonical versioned routes
-    # ------------------------------------------------------------------
-    path("api/v1/", include(_versioned_patterns)),
-    # ------------------------------------------------------------------
     # DEPRECATED — unversioned aliases kept for backward compatibility.
-    # New clients should use /api/v1/... equivalents above.
+    # New clients should use /api/v1/... equivalents below.
     # ------------------------------------------------------------------
     path("api/", include(_versioned_patterns)),
     path("api/", include(root_router.urls)),
+    # ------------------------------------------------------------------
+    # v1 — canonical versioned routes (registered last so reverse() returns
+    # /api/v1/... paths; Django builds _reverse_dict in reverse order so
+    # the last-registered name wins the reverse lookup).
+    # ------------------------------------------------------------------
+    path("api/v1/", include(_versioned_patterns)),
 ]


### PR DESCRIPTION
## Summary

- Prefixes all app-scoped routes with `/api/v1/` in `config/urls.py`
- Keeps existing unversioned `/api/` routes as deprecated backward-compat aliases with a comment
- Uses a shared `_versioned_patterns` list so both prefixes stay in sync — adding a new route needs one edit, not two
- Does **not** expose the flat root-router shortcuts under `/api/v1/` (they are backward-compat only; canonical v1 paths are `/api/v1/finance/invoices/`, `/api/v1/core/users/`, etc.)

## Test plan

- [x] `python manage.py check` — no issues
- [x] 644 backend tests pass
- [x] `/api/v1/crm/`, `/api/v1/jobs/`, `/api/v1/finance/`, `/api/v1/inventory/`, `/api/v1/core/` all resolve
- [x] Old `/api/crm/` etc. still resolve (backward compat preserved)
- [ ] Manual smoke: login → workspace loads → verify `/api/v1/core/auth/login/` responds

## Notes

`openapi.json` / `schema.d.ts` in `frontend/src/api/` still reference unversioned paths — they need regenerating once the schema snapshot CI step (PR 13) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)