### PR TITLE
PR 14: Observability and structured logging

### DIFF
--- a/backend/apps/core/middleware.py
+++ b/backend/apps/core/middleware.py
@@ -26,9 +26,7 @@ class RequestLogMiddleware:
         finally:
             duration_ms = round((time.monotonic() - started_at) * 1000, 2)
             user = self._request_user(request)
-            is_authenticated = bool(
-                user is not None and getattr(user, "is_authenticated", False)
-            )
+            is_authenticated = bool(user is not None and getattr(user, "is_authenticated", False))
             lab = getattr(user, "lab", None) if is_authenticated else None
             status_code = getattr(response, "status_code", 500)
 
@@ -44,11 +42,7 @@ class RequestLogMiddleware:
                     "status_code": status_code,
                     "duration_ms": duration_ms,
                     "user_id": getattr(user, "id", None) if is_authenticated else None,
-                    "username": (
-                        getattr(user, "get_username", lambda: "")()
-                        if is_authenticated
-                        else ""
-                    ),
+                    "username": (getattr(user, "get_username", lambda: "")() if is_authenticated else ""),
                     "lab_id": getattr(lab, "id", None),
                     "remote_addr": self._client_ip(request),
                 },

--- a/backend/apps/core/middleware.py
+++ b/backend/apps/core/middleware.py
@@ -1,3 +1,92 @@
+import logging
+import time
+import uuid
+
+request_logger = logging.getLogger("apps.core.request")
+
+
+class RequestLogMiddleware:
+    """Emit one structured log entry for every HTTP request."""
+
+    REQUEST_ID_HEADER = "HTTP_X_REQUEST_ID"
+    RESPONSE_HEADER = "X-Request-ID"
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        started_at = time.monotonic()
+        request_id = request.META.get(self.REQUEST_ID_HEADER) or uuid.uuid4().hex
+        request.request_id = request_id
+
+        response = None
+        try:
+            response = self.get_response(request)
+            return response
+        finally:
+            duration_ms = round((time.monotonic() - started_at) * 1000, 2)
+            user = self._request_user(request)
+            is_authenticated = bool(
+                user is not None and getattr(user, "is_authenticated", False)
+            )
+            lab = getattr(user, "lab", None) if is_authenticated else None
+            status_code = getattr(response, "status_code", 500)
+
+            if response is not None:
+                response[self.RESPONSE_HEADER] = request_id
+
+            request_logger.info(
+                "request_completed",
+                extra={
+                    "request_id": request_id,
+                    "method": request.method,
+                    "path": request.get_full_path(),
+                    "status_code": status_code,
+                    "duration_ms": duration_ms,
+                    "user_id": getattr(user, "id", None) if is_authenticated else None,
+                    "username": (
+                        getattr(user, "get_username", lambda: "")()
+                        if is_authenticated
+                        else ""
+                    ),
+                    "lab_id": getattr(lab, "id", None),
+                    "remote_addr": self._client_ip(request),
+                },
+            )
+
+    def _client_ip(self, request):
+        forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+        if forwarded_for:
+            return forwarded_for.split(",")[0].strip()
+        return request.META.get("REMOTE_ADDR", "")
+
+    def _request_user(self, request):
+        user = getattr(request, "user", None)
+        if user is not None and getattr(user, "is_authenticated", False):
+            return user
+
+        try:
+            from rest_framework_simplejwt.authentication import JWTAuthentication
+            from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+
+            from apps.core.cookie_auth import _ACCESS_COOKIE
+        except Exception:
+            return user
+
+        raw_token = request.COOKIES.get(_ACCESS_COOKIE)
+        if raw_token is None:
+            header = JWTAuthentication().get_header(request)
+            raw_token = JWTAuthentication().get_raw_token(header) if header else None
+        if raw_token is None:
+            return user
+
+        jwt = JWTAuthentication()
+        try:
+            return jwt.get_user(jwt.get_validated_token(raw_token))
+        except (InvalidToken, TokenError):
+            return user
+
+
 class ContentSecurityPolicyMiddleware:
     """Adds a Content-Security-Policy header to every response.
 

--- a/backend/apps/core/tests/test_observability.py
+++ b/backend/apps/core/tests/test_observability.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch
+
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.core.models import Lab, User
+
+
+class HealthCheckTests(APITestCase):
+    def test_health_check_returns_ok_when_database_available(self):
+        resp = self.client.get("/api/health/")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, {"status": "ok", "checks": {"database": "ok"}})
+
+    @patch("apps.core.views.connection.cursor")
+    def test_health_check_returns_503_when_database_unavailable(self, cursor):
+        cursor.side_effect = RuntimeError("database unavailable")
+
+        resp = self.client.get("/api/health/")
+
+        self.assertEqual(resp.status_code, 503)
+        self.assertEqual(
+            resp.data,
+            {"status": "unhealthy", "checks": {"database": "error"}},
+        )
+
+
+class RequestLoggingTests(APITestCase):
+    def setUp(self):
+        self.lab = Lab.objects.create(name="Logging Lab")
+        self.user = User.objects.create_user(
+            username="log_user",
+            password="pw",
+            email="log@test.sk",
+            role="admin",
+            lab=self.lab,
+        )
+
+    def test_request_log_includes_context_fields(self):
+        access_token = RefreshToken.for_user(self.user).access_token
+
+        with self.assertLogs("apps.core.request", level="INFO") as captured:
+            resp = self.client.get(
+                "/api/health/",
+                HTTP_AUTHORIZATION=f"Bearer {access_token}",
+                HTTP_X_REQUEST_ID="req-test-123",
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["X-Request-ID"], "req-test-123")
+
+        record = captured.records[0]
+        self.assertEqual(record.request_id, "req-test-123")
+        self.assertEqual(record.method, "GET")
+        self.assertEqual(record.path, "/api/health/")
+        self.assertEqual(record.status_code, 200)
+        self.assertEqual(record.user_id, self.user.id)
+        self.assertEqual(record.username, self.user.username)
+        self.assertEqual(record.lab_id, self.lab.id)
+        self.assertGreaterEqual(record.duration_ms, 0)

--- a/backend/apps/core/views.py
+++ b/backend/apps/core/views.py
@@ -5,7 +5,8 @@ from decimal import Decimal
 from django.db import connection, transaction
 from django.db.models import Count, Q, Sum
 from django.utils import timezone
-from rest_framework import permissions, status, viewsets
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import permissions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.response import Response
@@ -330,6 +331,38 @@ class CsrfView(APIView):
         from django.middleware.csrf import get_token
 
         return Response({"csrfToken": get_token(request)})
+
+
+class HealthCheckResponseSerializer(serializers.Serializer):
+    status = serializers.ChoiceField(choices=("ok", "unhealthy"))
+    checks = serializers.DictField(child=serializers.ChoiceField(choices=("ok", "error")))
+
+
+class HealthCheckView(APIView):
+    permission_classes = [permissions.AllowAny]
+    authentication_classes = []
+
+    @extend_schema(
+        responses={
+            200: HealthCheckResponseSerializer,
+            503: OpenApiResponse(
+                response=HealthCheckResponseSerializer,
+                description="Database connectivity check failed.",
+            ),
+        }
+    )
+    def get(self, request):
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT 1")
+                cursor.fetchone()
+        except Exception:
+            return Response(
+                {"status": "unhealthy", "checks": {"database": "error"}},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        return Response({"status": "ok", "checks": {"database": "ok"}})
 
 
 class SystemHealthView(APIView):

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -6,6 +6,8 @@ import os
 from datetime import timedelta
 from pathlib import Path
 
+from pythonjsonlogger import jsonlogger
+
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 SECRET_KEY = os.environ.get("SECRET_KEY", "django-insecure-dev-key-change-me")
@@ -46,6 +48,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "apps.core.middleware.RequestLogMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "apps.core.middleware.ContentSecurityPolicyMiddleware",
@@ -211,3 +214,62 @@ EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
 EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "0") == "1"
 DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "noreply@dentallab.sk")
 FRONTEND_BASE_URL = os.environ.get("FRONTEND_BASE_URL", "http://localhost:5173")
+
+
+class DefaultingJsonFormatter(jsonlogger.JsonFormatter):
+    """Add request fields as null/empty values when non-request logs omit them."""
+
+    DEFAULT_FIELDS = {
+        "request_id": None,
+        "method": None,
+        "path": None,
+        "status_code": None,
+        "duration_ms": None,
+        "user_id": None,
+        "username": "",
+        "lab_id": None,
+        "remote_addr": "",
+    }
+
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        for key, value in self.DEFAULT_FIELDS.items():
+            log_record.setdefault(key, value)
+
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "json": {
+            "()": "config.settings.base.DefaultingJsonFormatter",
+            "format": (
+                "%(asctime)s %(levelname)s %(name)s %(message)s "
+                "%(request_id)s %(method)s %(path)s %(status_code)s "
+                "%(duration_ms)s %(user_id)s %(username)s %(lab_id)s %(remote_addr)s"
+            ),
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "json",
+        }
+    },
+    "loggers": {
+        "apps.core.request": {
+            "handlers": ["console"],
+            "level": os.environ.get("REQUEST_LOG_LEVEL", "INFO"),
+            "propagate": False,
+        },
+        "django.request": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": os.environ.get("DJANGO_LOG_LEVEL", "INFO"),
+    },
+}

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -9,6 +9,7 @@ from apps.core.views import (
     AuditLogViewSet,
     DashboardStatsView,
     GlobalSearchView,
+    HealthCheckView,
     LabViewSet,
     NotificationViewSet,
     PermissionsView,
@@ -59,6 +60,7 @@ urlpatterns = [
     # ------------------------------------------------------------------
     # Swagger / OpenAPI schema — not versioned
     # ------------------------------------------------------------------
+    path("api/health/", HealthCheckView.as_view(), name="health"),
     path(
         "api/schema/",
         SpectacularAPIView.as_view(permission_classes=[IsAdminOrSuperadminPermission]),

--- a/backend/core/management/commands/seed_users.py
+++ b/backend/core/management/commands/seed_users.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
 
         # Create Normal User
         if not User.objects.filter(username="user").exists():
-            user = User.objects.create_user("user", "user@example.com", "user")
+            User.objects.create_user("user", "user@example.com", "user")
             self.stdout.write(
                 self.style.SUCCESS('Test user "user" created (password: user)')
             )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ gunicorn
 uvicorn
 django-filter
 drf-spectacular
+python-json-logger
 reportlab
 weasyprint
 Markdown

--- a/doc/openapi-baseline.yaml
+++ b/doc/openapi-baseline.yaml
@@ -2707,6 +2707,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/Subscription'
           description: ''
+  /api/health/:
+    get:
+      operationId: health_retrieve
+      tags:
+      - health
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthCheckResponse'
+          description: ''
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthCheckResponse'
+          description: Database connectivity check failed.
   /api/inventory/warehouse/:
     get:
       operationId: inventory_warehouse_list
@@ -9491,6 +9511,32 @@ components:
         * `delivery` - Delivery
         * `deadline` - Deadline
         * `other` - Other
+    HealthCheckResponse:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/HealthCheckResponseStatusEnum'
+        checks:
+          type: object
+          additionalProperties:
+            enum:
+            - ok
+            - error
+            type: string
+            description: |-
+              * `ok` - ok
+              * `error` - error
+      required:
+      - checks
+      - status
+    HealthCheckResponseStatusEnum:
+      enum:
+      - ok
+      - unhealthy
+      type: string
+      description: |-
+        * `ok` - ok
+        * `unhealthy` - unhealthy
     Invoice:
       type: object
       properties:

--- a/env/dev.env.example
+++ b/env/dev.env.example
@@ -1,7 +1,13 @@
+# Required by Django. Dev default enables debug pages; use DEBUG=0 outside local dev.
 DEBUG=1
+
+# Required. Example-only secret for local development; set a unique value per deployed env.
 SECRET_KEY=dev_secret_key
+
+# Required. Space-separated hosts Django will serve. Default: local Docker/dev hosts.
 DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1] backend
 
+# Required database settings for Django. Defaults match the postgres service below.
 SQL_ENGINE=django.db.backends.postgresql
 SQL_DATABASE=dental_db
 SQL_USER=hello_django
@@ -9,11 +15,21 @@ SQL_PASSWORD=hello_django
 SQL_HOST=db
 SQL_PORT=5432
 
+# Required database settings for the postgres container. Keep in sync with SQL_* above.
 POSTGRES_USER=hello_django
 POSTGRES_PASSWORD=hello_django
 POSTGRES_DB=dental_db
 
+# Optional local port overrides. Defaults expose backend on 8810 and frontend on 5367.
 BACKEND_PORT=8810
 FRONTEND_PORT=5367
+
+# Required for frontend API calls. Default points Vite at the local backend container port.
 VITE_API_URL=http://localhost:8810/api
+
+# Required when cookies/CSRF are enabled. Comma-separated origins allowed to call the API.
 CORS_ALLOWED_ORIGINS=http://localhost:5367,http://127.0.0.1:5367
+
+# Optional logging controls. Defaults: JSON logs at INFO, request logs at INFO.
+DJANGO_LOG_LEVEL=INFO
+REQUEST_LOG_LEVEL=INFO


### PR DESCRIPTION
## Summary
- add JSON request logging with request ID, user, lab, status, remote IP, and duration fields
- add unauthenticated `/api/health/` DB connectivity endpoint with 200/503 responses
- document dev env variables inline and update OpenAPI baseline
- clean up a legacy unused variable that blocked backend Ruff

## Validation
- docker compose --env-file env/dev.env.example -f compose/docker-compose.yml build backend
- docker compose --env-file env/dev.env.example -f compose/docker-compose.yml run --rm backend python manage.py test apps.core.tests.test_observability --noinput --verbosity=2
- docker compose --env-file env/dev.env.example -f compose/docker-compose.yml run --rm backend python manage.py test --noinput --verbosity=2
- docker compose --env-file env/dev.env.example -f compose/docker-compose.yml run --rm backend ruff check .
- cd frontend && npm run lint && npm run build
- docker compose --env-file env/dev.env.example -f compose/docker-compose.yml run --rm backend python manage.py generateschema > /tmp/openapi-current.yaml && diff -u doc/openapi-baseline.yaml /tmp/openapi-current.yaml
