### PR TITLE
Complete invoice workflow and PDF appendices

### DIFF
--- a/backend/apps/core/test_contracts.py
+++ b/backend/apps/core/test_contracts.py
@@ -455,9 +455,10 @@ class InvoiceContractTests(APITestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertGreater(len(response.data), 0)
+        self.assertGreater(response.data["count"], 0)
+        self.assertGreater(len(response.data["results"]), 0)
 
-        invoice_data = response.data[0]
+        invoice_data = response.data["results"][0]
 
         # Enriched fields must be present
         self.assertIn("clinic_name", invoice_data)

--- a/backend/apps/finance/invoice_service.py
+++ b/backend/apps/finance/invoice_service.py
@@ -5,6 +5,7 @@ Extracted from InvoiceViewSet so the logic can be tested independently
 and reused without going through the HTTP layer.
 """
 
+from copy import deepcopy
 from decimal import Decimal
 
 from django.conf import settings as django_settings
@@ -21,6 +22,137 @@ from .models import Invoice, InvoiceItem, InvoiceSequence, PriceList
 # ---------------------------------------------------------------------------
 # Pure helpers
 # ---------------------------------------------------------------------------
+
+
+def _serialize_invoice_breakdown(rows):
+    """Convert breakdown values to stable JSON-compatible invoice snapshot data."""
+    return [
+        {
+            **row,
+            "total": f"{Decimal(str(row['total'])):.2f}",
+            "procedures": [
+                {
+                    **procedure,
+                    "unit_price": f"{Decimal(str(procedure['unit_price'])):.2f}",
+                    "line_total": f"{Decimal(str(procedure['line_total'])):.2f}",
+                }
+                for procedure in row["procedures"]
+            ],
+            "recipes": [
+                {
+                    **recipe,
+                    "date": recipe["date"].isoformat()
+                    if hasattr(recipe["date"], "isoformat")
+                    else recipe["date"],
+                    "materials": [
+                        {
+                            **material,
+                            "quantity": str(material["quantity"]),
+                        }
+                        for material in recipe["materials"]
+                    ],
+                }
+                for recipe in row["recipes"]
+            ],
+        }
+        for row in rows
+    ]
+
+
+def build_invoice_breakdown(invoice, *, force_dynamic=False):
+    """Return the patient/job/procedure/recipe detail used by invoice appendices."""
+    if not force_dynamic and invoice.breakdown_snapshot:
+        return deepcopy(invoice.breakdown_snapshot)
+
+    grouped = {}
+    items = sorted(
+        invoice.items.all(),
+        key=lambda item: (item.job_id is None, item.job_id or 0, item.id),
+    )
+
+    for item in items:
+        job = item.job
+        key = f"job:{job.id}" if job else f"item:{item.id}"
+        if key not in grouped:
+            patient = getattr(job, "patient", None) if job else None
+            patient_name = (
+                f"{patient.first_name} {patient.last_name}".strip()
+                if patient
+                else "Bez pacienta"
+            )
+            grouped[key] = {
+                "job_id": job.id if job else None,
+                "patient_id": patient.id if patient else None,
+                "patient_name": patient_name,
+                "job_description": (job.description or "") if job else "",
+                "procedures": [],
+                "recipes": [],
+                "total": Decimal("0.00"),
+            }
+
+        row = grouped[key]
+        line_total = Decimal(str(item.line_total or 0))
+        row["procedures"].append(
+            {
+                "description": item.description or row["job_description"] or "Dentálna práca",
+                "quantity": item.quantity,
+                "unit_price": Decimal(str(item.unit_price or 0)),
+                "line_total": line_total,
+            }
+        )
+        row["total"] += line_total
+
+    jobs_by_id = {
+        item.job_id: item.job
+        for item in items
+        if item.job_id and item.job is not None
+    }
+    for row in grouped.values():
+        job = jobs_by_id.get(row["job_id"])
+        if not job:
+            continue
+        usages = sorted(
+            job.material_usages.all(),
+            key=lambda usage: (usage.date, usage.id),
+        )
+        row["recipes"] = [
+            {
+                "name": usage.recipe
+                or (usage.recipe_source.name if usage.recipe_source else "")
+                or "Individuálny materiálový záznam",
+                "date": usage.date,
+                "materials": [
+                    {
+                        "name": line.name,
+                        "code": line.code,
+                        "manufacturer": line.manufacturer,
+                        "lot": line.lot,
+                        "quantity": line.qty,
+                        "unit": line.unit,
+                    }
+                    for line in usage.lines.all()
+                ],
+            }
+            for usage in usages
+        ]
+
+    return list(grouped.values())
+
+
+def build_invoice_patient_summaries(invoice, breakdown=None):
+    """Aggregate invoice totals by patient for the patient-based invoice mode."""
+    summaries = {}
+    rows = breakdown if breakdown is not None else build_invoice_breakdown(invoice)
+    for row in rows:
+        key = row["patient_id"] or row["patient_name"]
+        if key not in summaries:
+            summaries[key] = {
+                "patient_id": row["patient_id"],
+                "patient_name": row["patient_name"],
+                "total": Decimal("0.00"),
+            }
+        summaries[key]["total"] += Decimal(str(row["total"]))
+    return list(summaries.values())
 
 
 def generate_invoice_number(lab):
@@ -147,7 +279,10 @@ def create_invoice(
 
     amounts = calculate_invoice_amounts(subtotal, invoice.vat_rate, invoice.discount_percent)
     invoice.total_amount = amounts["total_amount"]
-    invoice.save(update_fields=["total_amount"])
+    invoice.breakdown_snapshot = _serialize_invoice_breakdown(
+        build_invoice_breakdown(invoice, force_dynamic=True)
+    )
+    invoice.save(update_fields=["total_amount", "breakdown_snapshot"])
 
     sync_jobs_for_invoice_status(invoice, "issued")
 

--- a/backend/apps/finance/invoice_service.py
+++ b/backend/apps/finance/invoice_service.py
@@ -41,9 +41,7 @@ def _serialize_invoice_breakdown(rows):
             "recipes": [
                 {
                     **recipe,
-                    "date": recipe["date"].isoformat()
-                    if hasattr(recipe["date"], "isoformat")
-                    else recipe["date"],
+                    "date": recipe["date"].isoformat() if hasattr(recipe["date"], "isoformat") else recipe["date"],
                     "materials": [
                         {
                             **material,
@@ -75,11 +73,7 @@ def build_invoice_breakdown(invoice, *, force_dynamic=False):
         key = f"job:{job.id}" if job else f"item:{item.id}"
         if key not in grouped:
             patient = getattr(job, "patient", None) if job else None
-            patient_name = (
-                f"{patient.first_name} {patient.last_name}".strip()
-                if patient
-                else "Bez pacienta"
-            )
+            patient_name = f"{patient.first_name} {patient.last_name}".strip() if patient else "Bez pacienta"
             grouped[key] = {
                 "job_id": job.id if job else None,
                 "patient_id": patient.id if patient else None,
@@ -102,11 +96,7 @@ def build_invoice_breakdown(invoice, *, force_dynamic=False):
         )
         row["total"] += line_total
 
-    jobs_by_id = {
-        item.job_id: item.job
-        for item in items
-        if item.job_id and item.job is not None
-    }
+    jobs_by_id = {item.job_id: item.job for item in items if item.job_id and item.job is not None}
     for row in grouped.values():
         job = jobs_by_id.get(row["job_id"])
         if not job:
@@ -279,9 +269,7 @@ def create_invoice(
 
     amounts = calculate_invoice_amounts(subtotal, invoice.vat_rate, invoice.discount_percent)
     invoice.total_amount = amounts["total_amount"]
-    invoice.breakdown_snapshot = _serialize_invoice_breakdown(
-        build_invoice_breakdown(invoice, force_dynamic=True)
-    )
+    invoice.breakdown_snapshot = _serialize_invoice_breakdown(build_invoice_breakdown(invoice, force_dynamic=True))
     invoice.save(update_fields=["total_amount", "breakdown_snapshot"])
 
     sync_jobs_for_invoice_status(invoice, "issued")

--- a/backend/apps/finance/migrations/0012_invoice_breakdown_snapshot.py
+++ b/backend/apps/finance/migrations/0012_invoice_breakdown_snapshot.py
@@ -1,0 +1,107 @@
+from decimal import Decimal
+
+from django.db import migrations, models
+
+
+def snapshot_existing_invoices(apps, schema_editor):
+    Invoice = apps.get_model("finance", "Invoice")
+    InvoiceItem = apps.get_model("finance", "InvoiceItem")
+    MaterialUsage = apps.get_model("materials", "MaterialUsage")
+    MaterialUsageLine = apps.get_model("materials", "MaterialUsageLine")
+
+    for invoice in Invoice.objects.all().iterator(chunk_size=200):
+        items = list(
+            InvoiceItem.objects.filter(invoice_id=invoice.id)
+            .select_related("job__patient")
+            .order_by("job_id", "id")
+        )
+        grouped = {}
+        for item in items:
+            job = item.job
+            key = f"job:{job.id}" if job else f"item:{item.id}"
+            if key not in grouped:
+                patient = getattr(job, "patient", None) if job else None
+                grouped[key] = {
+                    "job_id": job.id if job else None,
+                    "patient_id": patient.id if patient else None,
+                    "patient_name": (
+                        f"{patient.first_name} {patient.last_name}".strip()
+                        if patient
+                        else "Bez pacienta"
+                    ),
+                    "job_description": (job.description or "") if job else "",
+                    "procedures": [],
+                    "recipes": [],
+                    "total": Decimal("0.00"),
+                }
+            row = grouped[key]
+            line_total = Decimal(str(item.line_total or 0))
+            row["procedures"].append(
+                {
+                    "description": item.description or row["job_description"] or "Dentálna práca",
+                    "quantity": item.quantity,
+                    "unit_price": f"{Decimal(str(item.unit_price or 0)):.2f}",
+                    "line_total": f"{line_total:.2f}",
+                }
+            )
+            row["total"] += line_total
+
+        job_ids = [row["job_id"] for row in grouped.values() if row["job_id"]]
+        usages_by_job = {}
+        usages = (
+            MaterialUsage.objects.filter(job_id__in=job_ids)
+            .select_related("recipe_source")
+            .order_by("date", "id")
+        )
+        usage_ids = [usage.id for usage in usages]
+        lines_by_usage = {}
+        for line in MaterialUsageLine.objects.filter(usage_id__in=usage_ids).order_by("id"):
+            lines_by_usage.setdefault(line.usage_id, []).append(
+                {
+                    "name": line.name,
+                    "code": line.code,
+                    "manufacturer": line.manufacturer,
+                    "lot": line.lot,
+                    "quantity": str(line.qty),
+                    "unit": line.unit,
+                }
+            )
+        for usage in usages:
+            usages_by_job.setdefault(usage.job_id, []).append(
+                {
+                    "name": usage.recipe
+                    or (usage.recipe_source.name if usage.recipe_source else "")
+                    or "Individuálny materiálový záznam",
+                    "date": usage.date.isoformat() if usage.date else None,
+                    "materials": lines_by_usage.get(usage.id, []),
+                }
+            )
+
+        snapshot = []
+        for row in grouped.values():
+            row["total"] = f"{row['total']:.2f}"
+            row["recipes"] = usages_by_job.get(row["job_id"], [])
+            snapshot.append(row)
+        invoice.breakdown_snapshot = snapshot
+        invoice.save(update_fields=["breakdown_snapshot"])
+
+
+def clear_snapshots(apps, schema_editor):
+    apps.get_model("finance", "Invoice").objects.update(breakdown_snapshot=[])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("finance", "0011_invoice_description_options"),
+        ("materials", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="invoice",
+            name="breakdown_snapshot",
+            field=models.JSONField(blank=True, default=list),
+        ),
+        migrations.RunPython(snapshot_existing_invoices, clear_snapshots),
+    ]

--- a/backend/apps/finance/models.py
+++ b/backend/apps/finance/models.py
@@ -79,6 +79,7 @@ class Invoice(models.Model):
     )
     custom_description = models.TextField(blank=True, default="")
     show_patient_list = models.BooleanField(default=True)
+    breakdown_snapshot = models.JSONField(blank=True, default=list)
 
     created_at = models.DateTimeField(auto_now_add=True)
     issued_at = models.DateTimeField(null=True, blank=True)

--- a/backend/apps/finance/serializers.py
+++ b/backend/apps/finance/serializers.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 
 from apps.core.models import AuditLog
 
+from . import invoice_service
 from .calculations import calculate_invoice_amounts, reverse_invoice_subtotal
 from .models import Invoice, InvoiceItem, PriceList, Subscription
 
@@ -85,6 +86,10 @@ class InvoiceStatusUpdateSerializer(serializers.Serializer):
     status = serializers.ChoiceField(choices=("draft", "issued", "paid", "cancelled"))
 
 
+class InvoiceEmailSerializer(serializers.Serializer):
+    email = serializers.EmailField(required=False, allow_blank=False)
+
+
 class InvoiceAuditLogEntrySerializer(serializers.Serializer):
     id = serializers.IntegerField()
     action = serializers.CharField()
@@ -93,6 +98,44 @@ class InvoiceAuditLogEntrySerializer(serializers.Serializer):
     created_at = serializers.DateTimeField()
     message = serializers.CharField(allow_blank=True, allow_null=True)
     metadata = serializers.DictField()
+
+
+class InvoiceMaterialLineSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    code = serializers.CharField()
+    manufacturer = serializers.CharField()
+    lot = serializers.CharField()
+    quantity = serializers.DecimalField(max_digits=12, decimal_places=3)
+    unit = serializers.CharField()
+
+
+class InvoiceRecipeSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    date = serializers.CharField(allow_blank=True, allow_null=True)
+    materials = InvoiceMaterialLineSerializer(many=True)
+
+
+class InvoiceProcedureSerializer(serializers.Serializer):
+    description = serializers.CharField()
+    quantity = serializers.IntegerField()
+    unit_price = serializers.DecimalField(max_digits=10, decimal_places=2)
+    line_total = serializers.DecimalField(max_digits=10, decimal_places=2)
+
+
+class InvoiceAppendixRowSerializer(serializers.Serializer):
+    job_id = serializers.IntegerField(allow_null=True)
+    patient_id = serializers.IntegerField(allow_null=True)
+    patient_name = serializers.CharField()
+    job_description = serializers.CharField(allow_blank=True)
+    procedures = InvoiceProcedureSerializer(many=True)
+    recipes = InvoiceRecipeSerializer(many=True)
+    total = serializers.DecimalField(max_digits=12, decimal_places=2)
+
+
+class InvoicePatientSummarySerializer(serializers.Serializer):
+    patient_id = serializers.IntegerField(allow_null=True)
+    patient_name = serializers.CharField()
+    total = serializers.DecimalField(max_digits=12, decimal_places=2)
 
 
 def _sk_date(d):
@@ -122,12 +165,17 @@ class InvoiceSerializer(serializers.ModelSerializer):
 
     items = InvoiceItemSerializer(many=True, read_only=True)
     clinic_name = serializers.CharField(source="clinic.name", read_only=True)
+    clinic_email = serializers.SerializerMethodField()
     patient_names = serializers.SerializerMethodField()
     subtotal_amount = serializers.SerializerMethodField()
+    discount_amount = serializers.SerializerMethodField()
+    taxable_amount = serializers.SerializerMethodField()
     vat_amount = serializers.SerializerMethodField()
     is_overdue = serializers.SerializerMethodField()
     days_overdue = serializers.SerializerMethodField()
     related_jobs = serializers.SerializerMethodField()
+    patient_summaries = serializers.SerializerMethodField()
+    appendix_rows = serializers.SerializerMethodField()
     formatted_total = serializers.SerializerMethodField()
     formatted_due_date = serializers.SerializerMethodField()
     formatted_issued_at = serializers.SerializerMethodField()
@@ -141,6 +189,7 @@ class InvoiceSerializer(serializers.ModelSerializer):
             "lab",
             "clinic",
             "clinic_name",
+            "clinic_email",
             "status",
             "document_type",
             "vat_rate",
@@ -150,6 +199,8 @@ class InvoiceSerializer(serializers.ModelSerializer):
             "show_patient_list",
             "total_amount",
             "subtotal_amount",
+            "discount_amount",
+            "taxable_amount",
             "vat_amount",
             "formatted_total",
             "formatted_due_date",
@@ -162,17 +213,24 @@ class InvoiceSerializer(serializers.ModelSerializer):
             "due_date",
             "items",
             "patient_names",
+            "patient_summaries",
+            "appendix_rows",
             "related_jobs",
             "audit_log",
         )
 
     def get_patient_names(self, obj):
-        patient_names = set()
-        for item in obj.items.select_related("job__patient").all():
-            patient = getattr(getattr(item, "job", None), "patient", None)
-            if patient:
-                patient_names.add(f"{patient.first_name} {patient.last_name}")
-        return sorted(patient_names)
+        return sorted(
+            {
+                row["patient_name"]
+                for row in self._breakdown(obj)
+                if row.get("patient_name") and row["patient_name"] != "Bez pacienta"
+            }
+        )
+
+    def get_clinic_email(self, obj):
+        contact_info = obj.clinic.contact_info or {}
+        return contact_info.get("email", "") if isinstance(contact_info, dict) else ""
 
     def get_formatted_total(self, obj):
         return _sk_amount(obj.total_amount)
@@ -192,6 +250,14 @@ class InvoiceSerializer(serializers.ModelSerializer):
         amounts = calculate_invoice_amounts(self._subtotal(obj), obj.vat_rate, obj.discount_percent)
         return f"{amounts['vat_amount']:.2f}"
 
+    def get_discount_amount(self, obj):
+        amounts = calculate_invoice_amounts(self._subtotal(obj), obj.vat_rate, obj.discount_percent)
+        return f"{amounts['discount_amount']:.2f}"
+
+    def get_taxable_amount(self, obj):
+        amounts = calculate_invoice_amounts(self._subtotal(obj), obj.vat_rate, obj.discount_percent)
+        return f"{amounts['taxable_amount']:.2f}"
+
     def _subtotal(self, obj):
         items = obj.items.all()
         if items:
@@ -209,7 +275,7 @@ class InvoiceSerializer(serializers.ModelSerializer):
     def get_related_jobs(self, obj):
         related = []
         seen = set()
-        for item in obj.items.select_related("job__patient").order_by("job_id"):
+        for item in sorted(obj.items.all(), key=lambda value: (value.job_id or 0, value.id)):
             job = item.job
             if not job or job.id in seen:
                 continue
@@ -226,6 +292,20 @@ class InvoiceSerializer(serializers.ModelSerializer):
                 }
             )
         return related
+
+    def _breakdown(self, obj):
+        if not hasattr(obj, "_invoice_breakdown_cache"):
+            obj._invoice_breakdown_cache = invoice_service.build_invoice_breakdown(obj)
+        return obj._invoice_breakdown_cache
+
+    @extend_schema_field(InvoicePatientSummarySerializer(many=True))
+    def get_patient_summaries(self, obj):
+        summaries = invoice_service.build_invoice_patient_summaries(obj, self._breakdown(obj))
+        return InvoicePatientSummarySerializer(summaries, many=True).data
+
+    @extend_schema_field(InvoiceAppendixRowSerializer(many=True))
+    def get_appendix_rows(self, obj):
+        return InvoiceAppendixRowSerializer(self._breakdown(obj), many=True).data
 
     @extend_schema_field(InvoiceAuditLogEntrySerializer(many=True))
     def get_audit_log(self, obj):
@@ -246,6 +326,17 @@ class InvoiceSerializer(serializers.ModelSerializer):
             }
             for log in logs
         ]
+
+
+class InvoiceListSerializer(InvoiceSerializer):
+    """Lightweight invoice representation for collection/workspace responses."""
+
+    class Meta(InvoiceSerializer.Meta):
+        fields = tuple(
+            field
+            for field in InvoiceSerializer.Meta.fields
+            if field not in {"patient_names", "patient_summaries", "appendix_rows", "audit_log"}
+        )
 
 
 class SubscriptionSerializer(serializers.ModelSerializer):

--- a/backend/apps/finance/serializers.py
+++ b/backend/apps/finance/serializers.py
@@ -335,7 +335,16 @@ class InvoiceListSerializer(InvoiceSerializer):
         fields = tuple(
             field
             for field in InvoiceSerializer.Meta.fields
-            if field not in {"patient_names", "patient_summaries", "appendix_rows", "audit_log"}
+            if field not in {"patient_summaries", "appendix_rows", "audit_log"}
+        )
+
+    def get_patient_names(self, obj):
+        return sorted(
+            {
+                f"{item.job.patient.first_name} {item.job.patient.last_name}"
+                for item in obj.items.all()
+                if item.job and item.job.patient
+            }
         )
 
 

--- a/backend/apps/finance/tests/test_invoice_actions.py
+++ b/backend/apps/finance/tests/test_invoice_actions.py
@@ -286,22 +286,22 @@ class InvoiceListFilterTests(APITestCase):
         self.client.force_authenticate(user=self.admin)
         resp = self.client.get("/api/finance/invoices/?status=paid")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.data), 1)
-        self.assertEqual(resp.data[0]["number"], "F-0002")
+        self.assertEqual(resp.data["count"], 1)
+        self.assertEqual(resp.data["results"][0]["number"], "F-0002")
 
     def test_document_type_filter(self):
         self.client.force_authenticate(user=self.admin)
         resp = self.client.get("/api/finance/invoices/?document_type=proforma")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.data), 1)
-        self.assertEqual(resp.data[0]["number"], "F-0003")
+        self.assertEqual(resp.data["count"], 1)
+        self.assertEqual(resp.data["results"][0]["number"], "F-0003")
 
     def test_clinic_id_filter(self):
         self.client.force_authenticate(user=self.admin)
         resp = self.client.get(f"/api/finance/invoices/?clinic_id={self.clinic_b.id}")
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.data), 1)
-        self.assertEqual(resp.data[0]["number"], "F-0002")
+        self.assertEqual(resp.data["count"], 1)
+        self.assertEqual(resp.data["results"][0]["number"], "F-0002")
 
     def test_date_range_filter(self):
         from datetime import date
@@ -310,7 +310,7 @@ class InvoiceListFilterTests(APITestCase):
         self.client.force_authenticate(user=self.admin)
         resp = self.client.get(f"/api/finance/invoices/?date_from={today.isoformat()}")
         self.assertEqual(resp.status_code, 200)
-        numbers = [inv["number"] for inv in resp.data]
+        numbers = [inv["number"] for inv in resp.data["results"]]
         self.assertIn("F-0001", numbers)
         self.assertIn("F-0003", numbers)
         self.assertNotIn("F-0002", numbers)
@@ -319,3 +319,6 @@ class InvoiceListFilterTests(APITestCase):
         self.client.force_authenticate(user=self.admin)
         resp = self.client.get("/api/finance/invoices/?clinic_id=notanumber")
         self.assertEqual(resp.status_code, 200)
+        self.assertIn("results", resp.data)
+        self.assertLessEqual(len(resp.data["results"]), 100)
+        self.assertNotIn("appendix_rows", resp.data["results"][0])

--- a/backend/apps/finance/tests/test_invoice_lifecycle.py
+++ b/backend/apps/finance/tests/test_invoice_lifecycle.py
@@ -11,6 +11,7 @@ from apps.core.test_helpers import RoleMatrixTestMixin
 from apps.crm.models import Clinic, Doctor, Patient
 from apps.finance.models import Invoice, InvoiceSequence
 from apps.jobs.models import Job, Technician
+from apps.materials.models import MaterialUsage, MaterialUsageLine
 
 
 class InvoiceLifecycleApiTests(APITestCase):
@@ -164,11 +165,71 @@ class InvoiceLifecycleApiTests(APITestCase):
             ],
         )
         self.assertGreaterEqual(len(response.data["items"]), 2)
+        self.assertEqual(
+            response.data["patient_summaries"],
+            [
+                {
+                    "patient_id": self.patient_a.id,
+                    "patient_name": "Alice Patient",
+                    "total": "320.00",
+                }
+            ],
+        )
+        self.assertEqual(len(response.data["appendix_rows"]), 2)
 
         self.job_a1.refresh_from_db()
         self.job_a2.refresh_from_db()
         self.assertEqual(self.job_a1.status, "finished_factured")
         self.assertEqual(self.job_a2.status, "finished_factured")
+
+    def test_invoice_appendix_contains_procedures_recipes_and_materials(self):
+        usage = MaterialUsage.objects.create(
+            lab=self.lab_a,
+            job=self.job_a1,
+            patient_label="Alice Patient",
+            technician="Tech A",
+            recipe="Zirkónový recept",
+        )
+        MaterialUsageLine.objects.create(
+            usage=usage,
+            name="Zirkónový disk",
+            code="ZR-01",
+            manufacturer="Dental Materials",
+            lot="LOT-2026-07",
+            qty="1.500",
+            unit="g",
+        )
+        self.client.force_authenticate(user=self.admin_a)
+
+        response = self.client.post(
+            "/api/finance/invoices/",
+            {"clinic_id": self.clinic_a.id, "job_ids": [self.job_a1.id]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        row = response.data["appendix_rows"][0]
+        self.assertEqual(row["patient_name"], "Alice Patient")
+        self.assertEqual(row["procedures"][0]["description"], "CROWN")
+        self.assertEqual(row["recipes"][0]["name"], "Zirkónový recept")
+        self.assertEqual(row["recipes"][0]["materials"][0]["name"], "Zirkónový disk")
+        self.assertEqual(row["recipes"][0]["materials"][0]["lot"], "LOT-2026-07")
+
+        invoice_id = response.data["id"]
+        self.patient_a.first_name = "Zmenené"
+        self.patient_a.save(update_fields=["first_name"])
+        usage.recipe = "Zmenený recept"
+        usage.save(update_fields=["recipe"])
+        material = usage.lines.get()
+        MaterialUsageLine.objects.filter(pk=material.pk).update(name="Zmenený materiál")
+
+        detail = self.client.get(f"/api/finance/invoices/{invoice_id}/")
+
+        self.assertEqual(detail.status_code, status.HTTP_200_OK)
+        snapshotted_row = detail.data["appendix_rows"][0]
+        self.assertEqual(snapshotted_row["patient_name"], "Alice Patient")
+        self.assertEqual(snapshotted_row["recipes"][0]["name"], "Zirkónový recept")
+        self.assertEqual(snapshotted_row["recipes"][0]["materials"][0]["name"], "Zirkónový disk")
 
     def test_create_invoice_uses_lab_billing_defaults(self):
         self.lab_a.invoice_prefix = "MOL"
@@ -305,6 +366,40 @@ class InvoiceLifecycleApiTests(APITestCase):
 
         self.assertEqual(pdf_resp.status_code, status.HTTP_200_OK)
         self.assertEqual(self._pdf_page_count(pdf_resp.content), 1)
+
+    def test_invoice_pdf_paginates_many_patients_without_dropping_appendix(self):
+        jobs = []
+        for index in range(30):
+            patient = Patient.objects.create(
+                lab=self.lab_a,
+                first_name=f"Pacient {index:02d}",
+                last_name="Veľmi dlhé priezvisko pre zalomenie",
+                birth_number=f"990101/{index:04d}",
+            )
+            jobs.append(
+                Job.objects.create(
+                    lab=self.lab_a,
+                    patient=patient,
+                    clinic=self.clinic_a,
+                    doctor=self.doctor_a,
+                    technician=self.tech_a,
+                    status="completed",
+                    price="10.00",
+                    description="Rozsiahly protetický úkon so zachovaným úplným popisom",
+                )
+            )
+        self.client.force_authenticate(user=self.admin_a)
+        create_resp = self.client.post(
+            "/api/finance/invoices/",
+            {"clinic_id": self.clinic_a.id, "job_ids": [job.id for job in jobs]},
+            format="json",
+        )
+        self.assertEqual(create_resp.status_code, status.HTTP_201_CREATED)
+
+        pdf_resp = self.client.get(f"/api/finance/invoices/{create_resp.data['id']}/pdf/")
+
+        self.assertEqual(pdf_resp.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(self._pdf_page_count(pdf_resp.content), 3)
 
     def test_non_superadmin_cannot_create_invoice_for_other_lab(self):
         self.client.force_authenticate(user=self.admin_a)
@@ -564,7 +659,7 @@ class ProformaInvoiceTests(APITestCase):
         self.client.force_authenticate(user=self.user)
         resp = self.client.get("/api/finance/invoices/")
         self.assertEqual(resp.status_code, 200)
-        self.assertTrue(any(i["document_type"] == "proforma" for i in resp.data))
+        self.assertTrue(any(i["document_type"] == "proforma" for i in resp.data["results"]))
 
     def test_invalid_document_type_rejected(self):
         job = self._create_job()

--- a/backend/apps/finance/views.py
+++ b/backend/apps/finance/views.py
@@ -1,5 +1,6 @@
 import calendar
 import csv
+import logging
 from datetime import date
 from decimal import Decimal
 from io import BytesIO, StringIO
@@ -17,10 +18,12 @@ from reportlab.graphics.barcode import qr
 from reportlab.graphics.shapes import Drawing
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import mm
+from reportlab.lib.utils import simpleSplit
 from reportlab.pdfgen import canvas
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -43,11 +46,23 @@ from .models import Invoice, PriceList, Subscription
 from .selectors import invoices_for_user, price_list_for_user
 from .serializers import (
     InvoiceCreateSerializer,
+    InvoiceEmailSerializer,
+    InvoiceListSerializer,
     InvoiceSerializer,
     InvoiceStatusUpdateSerializer,
     PriceListSerializer,
     SubscriptionSerializer,
 )
+
+logger = logging.getLogger(__name__)
+
+
+class InvoicePageNumberPagination(PageNumberPagination):
+    """Keep invoice collection responses bounded; detail data has its own endpoint."""
+
+    page_size = 100
+    page_size_query_param = "page_size"
+    max_page_size = 100
 
 
 def _write_invoice_audit(request, invoice, action, metadata=None, description=None):
@@ -138,10 +153,16 @@ class PriceListViewSet(TenantScopedQuerysetMixin, viewsets.ModelViewSet):
 class InvoiceViewSet(viewsets.ModelViewSet):
     queryset = Invoice.objects.all()
     serializer_class = InvoiceSerializer
+    pagination_class = InvoicePageNumberPagination
     permission_classes = [
         permissions.IsAuthenticated,
         IsReadOnlyOrAdminOrSuperadminPermission,
     ]
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return InvoiceListSerializer
+        return InvoiceSerializer
 
     def _build_qr_svg(self, payload, size=128):
         widget = qr.QrCodeWidget(payload)
@@ -159,6 +180,11 @@ class InvoiceViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         qs = invoices_for_user(self.request.user)
         qs = qs.select_related("clinic", "lab").prefetch_related("items__job__patient")
+        if self.action in {"retrieve", "pdf", "send_email", "update_status"}:
+            qs = qs.prefetch_related(
+                "items__job__material_usages__recipe_source",
+                "items__job__material_usages__lines",
+            )
 
         params = self.request.query_params
         if status_filter := params.get("status"):
@@ -175,7 +201,7 @@ class InvoiceViewSet(viewsets.ModelViewSet):
         if date_to := parse_date(params.get("date_to", "")):
             qs = qs.filter(due_date__lte=date_to)
 
-        return qs
+        return qs.order_by("-created_at", "-id")
 
     def create(self, request, *args, **kwargs):
         payload = InvoiceCreateSerializer(data=request.data)
@@ -237,8 +263,12 @@ class InvoiceViewSet(viewsets.ModelViewSet):
         """Email the invoice PDF to the clinic contact or a provided address."""
         invoice = self.get_object()
         clinic = invoice.clinic
+        payload = InvoiceEmailSerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
 
-        recipient = request.data.get("email") or (clinic.contact_info or {}).get("email") if clinic else None
+        clinic_contact = (clinic.contact_info or {}) if clinic else {}
+        clinic_email = clinic_contact.get("email") if isinstance(clinic_contact, dict) else None
+        recipient = payload.validated_data.get("email") or clinic_email
         if not recipient:
             detail = "Chýba e-mail príjemcu. Zadajte 'email' v požiadavke alebo nastavte clinic contact_info.email."
             return Response(
@@ -253,16 +283,19 @@ class InvoiceViewSet(viewsets.ModelViewSet):
 
         try:
             invoice_service.send_invoice_email(request.user, invoice, pdf_bytes, recipient)
-        except Exception as exc:
+        except Exception:
+            logger.exception("Invoice email delivery failed", extra={"invoice_id": invoice.id})
             return Response(
-                {"detail": f"Odoslanie e-mailu zlyhalo: {exc}"},
+                {"detail": "Odoslanie e-mailu zlyhalo. Skontrolujte nastavenie odosielania a skúste to znova."},
                 status=status.HTTP_502_BAD_GATEWAY,
             )
         return Response({"sent_to": recipient, "invoice": invoice.number})
 
     def _render_invoice_pdf(self, invoice, buffer):
         """Render the invoice PDF into buffer (shared by pdf action and send_email)."""
-        items = invoice.items.select_related("job__patient").all()
+        items = list(invoice.items.select_related("job__patient").all())
+        breakdown = invoice_service.build_invoice_breakdown(invoice)
+        patient_summaries = invoice_service.build_invoice_patient_summaries(invoice, breakdown)
         lab = invoice.lab
         clinic = invoice.clinic
 
@@ -274,6 +307,23 @@ class InvoiceViewSet(viewsets.ModelViewSet):
         def hline(y, x1=None, x2=None):
             pdf.setLineWidth(0.3)
             pdf.line(x1 or L, y, x2 or R, y)
+
+        def wrapped_lines(value, font_name, font_size, max_width):
+            return simpleSplit(str(value or ""), font_name, font_size, max_width) or [""]
+
+        def invoice_continuation_page():
+            pdf.showPage()
+            pdf.setFont("Helvetica-Bold", 14)
+            pdf.drawString(L, height - 18 * mm, doc_label)
+            pdf.setFont("Helvetica", 9)
+            pdf.drawString(L, height - 24 * mm, f"Číslo: {invoice.number} — pokračovanie")
+            hline(height - 30 * mm)
+            page_y = height - 38 * mm
+            pdf.setFont("Helvetica-Bold", 9)
+            pdf.drawString(L, page_y, "Pacient")
+            pdf.drawRightString(R, page_y, "Spolu")
+            hline(page_y - 2 * mm)
+            return page_y - 8 * mm
 
         if lab.enable_qr_payment and lab.bank_account:
             iban = (lab.bank_account or "").replace(" ", "")
@@ -354,35 +404,44 @@ class InvoiceViewSet(viewsets.ModelViewSet):
 
             ty = th - 8 * mm
             pdf.setFont("Helvetica", 9)
-            pdf.drawString(
-                L,
-                ty,
-                (invoice.custom_description or "Protetické práce")[:95],
+            description_lines = wrapped_lines(
+                invoice.custom_description or "Protetické práce",
+                "Helvetica",
+                9,
+                145 * mm,
             )
-            pdf.drawRightString(
-                R,
-                ty,
-                format_sk_currency(sum((item.line_total for item in items), Decimal())),
-            )
-            ty -= 6 * mm
+            for line_index, line in enumerate(description_lines):
+                pdf.drawString(L, ty, line)
+                if line_index == 0:
+                    pdf.drawRightString(
+                        R,
+                        ty,
+                        format_sk_currency(sum((item.line_total for item in items), Decimal())),
+                    )
+                ty -= 4.5 * mm
+            ty -= 1.5 * mm
         else:
             pdf.setFont("Helvetica-Bold", 9)
-            pdf.drawString(L, th, "Popis")
-            pdf.drawRightString(120 * mm, th, "Mn.")
-            pdf.drawRightString(148 * mm, th, "Jed. cena")
+            pdf.drawString(L, th, "Pacient")
             pdf.drawRightString(R, th, "Spolu")
             hline(th - 2 * mm)
 
             ty = th - 8 * mm
-            pdf.setFont("Helvetica", 9)
-            for item in items[:30]:
-                if ty < 55 * mm:
-                    break
-                pdf.drawString(L, ty, str(item.description or "")[:60])
-                pdf.drawRightString(120 * mm, ty, str(item.quantity))
-                pdf.drawRightString(148 * mm, ty, format_sk_currency(item.unit_price))
-                pdf.drawRightString(R, ty, format_sk_currency(item.line_total))
-                ty -= 5 * mm
+            for summary in patient_summaries:
+                name_lines = wrapped_lines(
+                    summary["patient_name"],
+                    "Helvetica",
+                    9,
+                    145 * mm,
+                )
+                row_height = max(5, len(name_lines) * 4.5) * mm
+                if ty - row_height < 55 * mm:
+                    ty = invoice_continuation_page()
+                pdf.setFont("Helvetica", 9)
+                for line_index, line in enumerate(name_lines):
+                    pdf.drawString(L, ty - line_index * 4.5 * mm, line)
+                pdf.drawRightString(R, ty, format_sk_currency(summary["total"]))
+                ty -= row_height
 
         hline(ty)
         vat_rate = Decimal(str(invoice.vat_rate or 0))
@@ -395,6 +454,10 @@ class InvoiceViewSet(viewsets.ModelViewSet):
             subtotal = reverse_invoice_subtotal(total, vat_rate, discount)
         amounts = calculate_invoice_amounts(subtotal, vat_rate, discount)
         vat_amount = amounts["vat_amount"]
+
+        if ty < 52 * mm:
+            ty = invoice_continuation_page()
+            hline(ty)
 
         ty -= 6 * mm
         pdf.setFont("Helvetica", 9)
@@ -431,38 +494,111 @@ class InvoiceViewSet(viewsets.ModelViewSet):
         if lab.invoice_default_note:
             ty -= 6 * mm
             pdf.setFont("Helvetica", 8)
-            pdf.drawString(L, ty, lab.invoice_default_note[:120])
+            for note_line in wrapped_lines(
+                lab.invoice_default_note,
+                "Helvetica",
+                8,
+                R - L,
+            ):
+                pdf.drawString(L, ty, note_line)
+                ty -= 4 * mm
 
         if invoice.show_patient_list:
-            pdf.showPage()
-            pdf.setFont("Helvetica-Bold", 14)
-            pdf.drawString(L, height - 18 * mm, "Príloha k faktúre")
-            pdf.setFont("Helvetica", 10)
-            pdf.drawString(L, height - 25 * mm, f"Faktúra: {invoice.number}")
-            hline(height - 31 * mm)
+            def appendix_page():
+                pdf.showPage()
+                pdf.setFont("Helvetica-Bold", 14)
+                pdf.drawString(L, height - 18 * mm, "Príloha k faktúre")
+                pdf.setFont("Helvetica", 10)
+                pdf.drawString(L, height - 25 * mm, f"Faktúra: {invoice.number}")
+                hline(height - 31 * mm)
+                page_y = height - 40 * mm
+                pdf.setFont("Helvetica-Bold", 8)
+                pdf.drawString(L, page_y, "Pacient")
+                pdf.drawString(58 * mm, page_y, "Úkon / recept")
+                pdf.drawRightString(148 * mm, page_y, "Množstvo")
+                pdf.drawRightString(R, page_y, "Spolu")
+                hline(page_y - 2 * mm)
+                return page_y - 7 * mm
 
-            py = height - 40 * mm
-            pdf.setFont("Helvetica-Bold", 8)
-            pdf.drawString(L, py, "Pacient")
-            pdf.drawString(58 * mm, py, "Práca")
-            pdf.drawRightString(148 * mm, py, "Množstvo")
-            pdf.drawRightString(R, py, "Spolu")
-            hline(py - 2 * mm)
-            py -= 7 * mm
-            pdf.setFont("Helvetica", 8)
-            for item in items:
-                if py < 20 * mm:
-                    pdf.showPage()
-                    py = height - 20 * mm
+            py = appendix_page()
+            for row in breakdown:
+                first_procedure = True
+                for procedure in row["procedures"]:
+                    patient_lines = wrapped_lines(
+                        row["patient_name"] if first_procedure else "",
+                        "Helvetica",
+                        8,
+                        38 * mm,
+                    )
+                    procedure_lines = wrapped_lines(
+                        procedure["description"],
+                        "Helvetica",
+                        8,
+                        82 * mm,
+                    )
+                    line_count = max(len(patient_lines), len(procedure_lines))
+                    row_height = max(5, line_count * 4) * mm
+                    if py - row_height < 20 * mm:
+                        py = appendix_page()
                     pdf.setFont("Helvetica", 8)
-                job = item.job
-                patient = getattr(job, "patient", None) if job else None
-                patient_name = f"{patient.first_name} {patient.last_name}".strip() if patient else "Bez pacienta"
-                pdf.drawString(L, py, patient_name[:28])
-                pdf.drawString(58 * mm, py, str(item.description or "")[:45])
-                pdf.drawRightString(148 * mm, py, str(item.quantity))
-                pdf.drawRightString(R, py, format_sk_currency(item.line_total))
-                py -= 5 * mm
+                    for line_index, line in enumerate(patient_lines):
+                        pdf.drawString(L, py - line_index * 4 * mm, line)
+                    for line_index, line in enumerate(procedure_lines):
+                        pdf.drawString(58 * mm, py - line_index * 4 * mm, line)
+                    pdf.drawRightString(148 * mm, py, str(procedure["quantity"]))
+                    pdf.drawRightString(R, py, format_sk_currency(procedure["line_total"]))
+                    py -= row_height
+                    first_procedure = False
+
+                for recipe in row["recipes"]:
+                    recipe_date = recipe["date"]
+                    if hasattr(recipe_date, "strftime"):
+                        recipe_date = recipe_date.strftime("%d.%m.%Y")
+                    recipe_lines = wrapped_lines(
+                        f"Recept: {recipe['name']}" + (f" ({recipe_date})" if recipe_date else ""),
+                        "Helvetica-Bold",
+                        7.5,
+                        120 * mm,
+                    )
+                    recipe_height = len(recipe_lines) * 4 * mm
+                    if py - recipe_height < 20 * mm:
+                        py = appendix_page()
+                    pdf.setFont("Helvetica-Bold", 7.5)
+                    for line in recipe_lines:
+                        pdf.drawString(62 * mm, py, line)
+                        py -= 4 * mm
+                    pdf.setFont("Helvetica", 7)
+                    for material in recipe["materials"]:
+                        material_text = " · ".join(
+                            filter(
+                                None,
+                                [
+                                    material["name"],
+                                    material["code"],
+                                    f"LOT {material['lot']}" if material["lot"] else "",
+                                    material["manufacturer"],
+                                ],
+                            )
+                        )
+                        material_lines = wrapped_lines(
+                            material_text,
+                            "Helvetica",
+                            7,
+                            72 * mm,
+                        )
+                        material_height = max(4, len(material_lines) * 3.5) * mm
+                        if py - material_height < 18 * mm:
+                            py = appendix_page()
+                            pdf.setFont("Helvetica", 7)
+                        for line_index, line in enumerate(material_lines):
+                            pdf.drawString(66 * mm, py - line_index * 3.5 * mm, line)
+                        pdf.drawRightString(
+                            148 * mm,
+                            py,
+                            f"{material['quantity']} {material['unit']}",
+                        )
+                        py -= material_height
+                py -= 2 * mm
 
         pdf.showPage()
         pdf.save()

--- a/backend/apps/finance/views.py
+++ b/backend/apps/finance/views.py
@@ -504,6 +504,7 @@ class InvoiceViewSet(viewsets.ModelViewSet):
                 ty -= 4 * mm
 
         if invoice.show_patient_list:
+
             def appendix_page():
                 pdf.showPage()
                 pdf.setFont("Helvetica-Bold", 14)

--- a/doc/openapi-baseline.yaml
+++ b/doc/openapi-baseline.yaml
@@ -2032,7 +2032,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedInvoiceList'
+                $ref: '#/components/schemas/PaginatedInvoiceListList'
           description: ''
     post:
       operationId: finance_invoices_create
@@ -3023,7 +3023,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedInvoiceList'
+                $ref: '#/components/schemas/PaginatedInvoiceListList'
           description: ''
     post:
       operationId: invoices_create
@@ -7828,7 +7828,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedInvoiceList'
+                $ref: '#/components/schemas/PaginatedInvoiceListList'
           description: ''
     post:
       operationId: v1_finance_invoices_create
@@ -11231,8 +11231,11 @@ components:
         clinic_name:
           type: string
           readOnly: true
+        clinic_email:
+          type: string
+          readOnly: true
         status:
-          $ref: '#/components/schemas/InvoiceStatusEnum'
+          $ref: '#/components/schemas/Status12cEnum'
         document_type:
           $ref: '#/components/schemas/DocumentTypeEnum'
         vat_rate:
@@ -11254,6 +11257,12 @@ components:
           format: decimal
           pattern: ^-?\d{0,10}(?:\.\d{0,2})?$
         subtotal_amount:
+          type: string
+          readOnly: true
+        discount_amount:
+          type: string
+          readOnly: true
+        taxable_amount:
           type: string
           readOnly: true
         vat_amount:
@@ -11298,6 +11307,16 @@ components:
         patient_names:
           type: string
           readOnly: true
+        patient_summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoicePatientSummary'
+          readOnly: true
+        appendix_rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceAppendixRow'
+          readOnly: true
         related_jobs:
           type: string
           readOnly: true
@@ -11307,11 +11326,14 @@ components:
             $ref: '#/components/schemas/InvoiceAuditLogEntry'
           readOnly: true
       required:
+      - appendix_rows
       - audit_log
       - clinic
+      - clinic_email
       - clinic_name
       - created_at
       - days_overdue
+      - discount_amount
       - formatted_due_date
       - formatted_issued_at
       - formatted_total
@@ -11321,9 +11343,44 @@ components:
       - lab
       - number
       - patient_names
+      - patient_summaries
       - related_jobs
       - subtotal_amount
+      - taxable_amount
       - vat_amount
+    InvoiceAppendixRow:
+      type: object
+      properties:
+        job_id:
+          type: integer
+          nullable: true
+        patient_id:
+          type: integer
+          nullable: true
+        patient_name:
+          type: string
+        job_description:
+          type: string
+        procedures:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceProcedure'
+        recipes:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceRecipe'
+        total:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,10}(?:\.\d{0,2})?$
+      required:
+      - job_description
+      - job_id
+      - patient_id
+      - patient_name
+      - procedures
+      - recipes
+      - total
     InvoiceAuditLogEntry:
       type: object
       properties:
@@ -11382,18 +11439,194 @@ components:
       - description
       - id
       - invoice
-    InvoiceStatusEnum:
-      enum:
-      - draft
-      - issued
-      - paid
-      - cancelled
-      type: string
-      description: |-
-        * `draft` - Koncept
-        * `issued` - Vystavená
-        * `paid` - Zaplatená
-        * `cancelled` - Zrušená
+    InvoiceList:
+      type: object
+      description: Lightweight invoice representation for collection/workspace responses.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        number:
+          type: string
+          maxLength: 50
+        lab:
+          type: integer
+        clinic:
+          type: integer
+        clinic_name:
+          type: string
+          readOnly: true
+        clinic_email:
+          type: string
+          readOnly: true
+        status:
+          $ref: '#/components/schemas/Status12cEnum'
+        document_type:
+          $ref: '#/components/schemas/DocumentTypeEnum'
+        vat_rate:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,3}(?:\.\d{0,2})?$
+        discount_percent:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,3}(?:\.\d{0,2})?$
+        description_mode:
+          $ref: '#/components/schemas/DescriptionModeEnum'
+        custom_description:
+          type: string
+        show_patient_list:
+          type: boolean
+        total_amount:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,10}(?:\.\d{0,2})?$
+        subtotal_amount:
+          type: string
+          readOnly: true
+        discount_amount:
+          type: string
+          readOnly: true
+        taxable_amount:
+          type: string
+          readOnly: true
+        vat_amount:
+          type: string
+          readOnly: true
+        formatted_total:
+          type: string
+          readOnly: true
+        formatted_due_date:
+          type: string
+          readOnly: true
+        formatted_issued_at:
+          type: string
+          readOnly: true
+        is_overdue:
+          type: string
+          readOnly: true
+        days_overdue:
+          type: string
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        issued_at:
+          type: string
+          format: date-time
+          nullable: true
+        paid_at:
+          type: string
+          format: date-time
+          nullable: true
+        due_date:
+          type: string
+          format: date
+          nullable: true
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceItem'
+          readOnly: true
+        related_jobs:
+          type: string
+          readOnly: true
+      required:
+      - clinic
+      - clinic_email
+      - clinic_name
+      - created_at
+      - days_overdue
+      - discount_amount
+      - formatted_due_date
+      - formatted_issued_at
+      - formatted_total
+      - id
+      - is_overdue
+      - items
+      - lab
+      - number
+      - related_jobs
+      - subtotal_amount
+      - taxable_amount
+      - vat_amount
+    InvoiceMaterialLine:
+      type: object
+      properties:
+        name:
+          type: string
+        code:
+          type: string
+        manufacturer:
+          type: string
+        lot:
+          type: string
+        quantity:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,9}(?:\.\d{0,3})?$
+        unit:
+          type: string
+      required:
+      - code
+      - lot
+      - manufacturer
+      - name
+      - quantity
+      - unit
+    InvoicePatientSummary:
+      type: object
+      properties:
+        patient_id:
+          type: integer
+          nullable: true
+        patient_name:
+          type: string
+        total:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,10}(?:\.\d{0,2})?$
+      required:
+      - patient_id
+      - patient_name
+      - total
+    InvoiceProcedure:
+      type: object
+      properties:
+        description:
+          type: string
+        quantity:
+          type: integer
+        unit_price:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+        line_total:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
+      required:
+      - description
+      - line_total
+      - quantity
+      - unit_price
+    InvoiceRecipe:
+      type: object
+      properties:
+        name:
+          type: string
+        date:
+          type: string
+          nullable: true
+        materials:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceMaterialLine'
+      required:
+      - date
+      - materials
+      - name
     Job:
       type: object
       properties:
@@ -12236,7 +12469,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Doctor'
-    PaginatedInvoiceList:
+    PaginatedInvoiceListList:
       type: object
       required:
       - count
@@ -12258,7 +12491,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Invoice'
+            $ref: '#/components/schemas/InvoiceList'
     PaginatedJobList:
       type: object
       required:
@@ -12801,8 +13034,11 @@ components:
         clinic_name:
           type: string
           readOnly: true
+        clinic_email:
+          type: string
+          readOnly: true
         status:
-          $ref: '#/components/schemas/InvoiceStatusEnum'
+          $ref: '#/components/schemas/Status12cEnum'
         document_type:
           $ref: '#/components/schemas/DocumentTypeEnum'
         vat_rate:
@@ -12824,6 +13060,12 @@ components:
           format: decimal
           pattern: ^-?\d{0,10}(?:\.\d{0,2})?$
         subtotal_amount:
+          type: string
+          readOnly: true
+        discount_amount:
+          type: string
+          readOnly: true
+        taxable_amount:
           type: string
           readOnly: true
         vat_amount:
@@ -12867,6 +13109,16 @@ components:
           readOnly: true
         patient_names:
           type: string
+          readOnly: true
+        patient_summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoicePatientSummary'
+          readOnly: true
+        appendix_rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/InvoiceAppendixRow'
           readOnly: true
         related_jobs:
           type: string
@@ -13832,6 +14084,18 @@ components:
         * `admin` - Administrátor laboratória
         * `user` - Používateľ
         * `technician` - Technik
+    Status12cEnum:
+      enum:
+      - draft
+      - issued
+      - paid
+      - cancelled
+      type: string
+      description: |-
+        * `draft` - Koncept
+        * `issued` - Vystavená
+        * `paid` - Zaplatená
+        * `cancelled` - Zrušená
     Subscription:
       type: object
       properties:

--- a/doc/openapi-baseline.yaml
+++ b/doc/openapi-baseline.yaml
@@ -11529,6 +11529,9 @@ components:
           items:
             $ref: '#/components/schemas/InvoiceItem'
           readOnly: true
+        patient_names:
+          type: string
+          readOnly: true
         related_jobs:
           type: string
           readOnly: true
@@ -11547,6 +11550,7 @@ components:
       - items
       - lab
       - number
+      - patient_names
       - related_jobs
       - subtotal_amount
       - taxable_amount

--- a/frontend/e2e/invoice-flow.spec.js
+++ b/frontend/e2e/invoice-flow.spec.js
@@ -127,6 +127,7 @@ test.describe('Invoice lifecycle', () => {
       const inv = await window.MolarisAPI.createRecord('/invoices/', {
         clinic_id: workspace.clinics[0].id,
         job_ids: [job.id],
+        discount_percent: 10,
       });
       return inv.id;
     }, ws);
@@ -155,5 +156,33 @@ test.describe('Invoice lifecycle', () => {
     // primary action is marking it as paid.
     await expect(page.locator('body')).toContainText('Zatvoriť', { timeout: 5000 });
     await expect(page.getByRole('button', { name: 'Zaplatená', exact: true })).toBeVisible({ timeout: 5000 });
+
+    // Preview uses the exact backend-calculated discounted total.
+    await page.getByRole('button', { name: 'Náhľad PDF', exact: true }).click();
+    const formattedTotal = new Intl.NumberFormat('sk-SK', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(Number(createdInvoice.raw.total_amount));
+    await expect(page.locator('.molaris-print-content')).toContainText(`${formattedTotal} €`, { timeout: 5000 });
+    await page.getByRole('button', { name: '✕ Zatvoriť', exact: true }).click();
+
+    // The confirmation names the exact clinic recipient and sends to the
+    // dedicated action endpoint.
+    const recipient = createdInvoice.raw.clinic_email;
+    expect(recipient).toBeTruthy();
+    let sendPayload = null;
+    await page.route(`**/api/invoices/${invoiceId}/send-email/`, async (route) => {
+      sendPayload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ sent_to: recipient, invoice: createdInvoice.number }),
+      });
+    });
+    await page.getByRole('button', { name: 'Poslať klinike', exact: true }).click();
+    await expect(page.locator('body')).toContainText(recipient);
+    await page.getByRole('button', { name: 'Poslať e-mail', exact: true }).click();
+    await expect.poll(() => sendPayload).not.toBeNull();
+    expect(sendPayload).toEqual({});
   });
 });

--- a/frontend/src/api/api-client.js
+++ b/frontend/src/api/api-client.js
@@ -52,6 +52,7 @@ window.MolarisAPI = {
   updateInvoiceStatus: finance.updateInvoiceStatus,
   deleteInvoice: finance.deleteInvoice,
   fetchInvoiceDetail: finance.fetchInvoiceDetail,
+  sendInvoiceEmail: finance.sendInvoiceEmail,
   downloadInvoicePdf: finance.downloadInvoicePdf,
   downloadInvoicesExport: finance.downloadInvoicesExport,
   fetchCurrentLab: auth.fetchCurrentLab,

--- a/frontend/src/api/finance.js
+++ b/frontend/src/api/finance.js
@@ -5,7 +5,8 @@ import { normalizeInvoice, normalizePriceItem } from './normalize.js';
 
 /** @returns {Promise<Schemas['Invoice'][]>} */
 export async function fetchInvoices() {
-  return request('/invoices/');
+  const payload = await request('/invoices/');
+  return Array.isArray(payload) ? payload : (payload.results || []);
 }
 
 /** @returns {Promise<Schemas['PriceList'][]>} */
@@ -41,6 +42,16 @@ export async function downloadInvoicePdf(id, filename) {
 /** @param {number} id */
 export async function fetchInvoiceDetail(id) {
   return request(`/invoices/${id}/`);
+}
+
+/** @param {number} id @param {string} [email] */
+export async function sendInvoiceEmail(id, email) {
+  const result = await request(`/invoices/${id}/send-email/`, {
+    method: 'POST',
+    body: JSON.stringify(email ? { email } : {}),
+  });
+  _refreshWorkspace();
+  return result;
 }
 
 /** @param {'csv'|'xlsx'} [format] */

--- a/frontend/src/api/workspace.js
+++ b/frontend/src/api/workspace.js
@@ -21,7 +21,8 @@ export async function loadWorkspace() {
   const clinics = clinicsRaw.map((clinic) => normalizeClinic(clinic, jobs));
   const normalizedDoctors = doctors.map((doctor) => normalizeDoctor(doctor, jobs));
   const normalizedTechnicians = technicians.map((technician) => normalizeTechnician(technician, jobs));
-  const normalizedInvoices = invoices.map(normalizeInvoice);
+  const invoiceRows = Array.isArray(invoices) ? invoices : (invoices.results || []);
+  const normalizedInvoices = invoiceRows.map(normalizeInvoice);
   const normalizedPriceList = priceList.map(normalizePriceItem);
   const normalizedWarehouse = warehouse.map(normalizeWarehouseItem);
   const calendarEvents = jobs.slice(0, 24).map(normalizeCalendarEvent);

--- a/frontend/src/components/CreateDrawers.jsx
+++ b/frontend/src/components/CreateDrawers.jsx
@@ -250,7 +250,7 @@ const CREATE_ENTITY_CONFIG = {
   },
   invoice: {
     title: 'Nová faktúra',
-    subtitle: 'Vystavenie faktúry z dokončených prác.',
+    subtitle: 'Vyberte faktúru s pacientmi alebo diskrétnu faktúru s voľným textom. Detailný rozpis sa priloží automaticky.',
     saveText: 'Vytvoriť faktúru',
     width: 720,
     columns: '1fr 1fr',
@@ -262,15 +262,14 @@ const CREATE_ENTITY_CONFIG = {
       return [
         { name: 'clinic_id', label: 'Klinika', required: true, type: 'select', options: (workspace.clinics || []).map((c) => ({ value: String(c.id), label: c.name })) },
         { name: 'doctor_id', label: 'Lekár', type: 'select', placeholder: 'Všetci lekári', options: doctors.map((d) => ({ value: String(d.id), label: `${d.title ? `${d.title} ` : ''}${d.first} ${d.last}`.trim() })) },
-        { name: 'description_mode', label: 'Popis na faktúre', type: 'select', options: [
-          { value: 'structured', label: 'Štruktúrovaný rozpis výkonov' },
-          { value: 'custom', label: 'Voľný popis' },
+        { name: 'description_mode', label: 'Typ faktúry', type: 'select', options: [
+          { value: 'structured', label: 'S pacientmi – mená a sumy' },
+          { value: 'custom', label: 'Bez pacientov – voľný text' },
         ] },
-        { name: 'show_patient_list', label: 'Príloha', type: 'checkbox', placeholder: 'Pridať zoznam pacientov a prác ako prílohu' },
         ...(form.description_mode === 'custom'
-          ? [{ name: 'custom_description', label: 'Voľný popis', type: 'textarea', rows: 2, required: true, helpText: 'Napr. Protetické práce.' }]
+          ? [{ name: 'custom_description', label: 'Text na hlavnej faktúre', type: 'textarea', rows: 2, required: true, helpText: 'Mená pacientov zostanú iba v prílohe. Napr. „Protetické práce podľa prílohy“.' }]
           : []),
-        { name: 'job_ids', label: 'Pacienti/práce', type: 'job-checklist', jobs, helpText: 'Predvolene sú vybrané všetky dokončené nefakturované práce zvoleného lekára.' },
+        { name: 'job_ids', label: 'Pacienti/práce', type: 'job-checklist', jobs, helpText: 'Predvolene sú vybrané všetky dokončené nefakturované práce zvoleného lekára. Príloha bude obsahovať úkony aj použité recepty a materiály.' },
       ];
     },
     submit: (form) => window.MolarisAPI.createRecord('/invoices/', {
@@ -278,7 +277,7 @@ const CREATE_ENTITY_CONFIG = {
       job_ids: (Array.isArray(form.job_ids) ? form.job_ids : []).map((id) => Number(id)).filter(Boolean),
       description_mode: form.description_mode || 'structured',
       custom_description: form.description_mode === 'custom' ? String(form.custom_description || '').trim() : '',
-      show_patient_list: !!form.show_patient_list,
+      show_patient_list: true,
     }),
   },
 };

--- a/frontend/src/components/InvoicePrintOverlay.jsx
+++ b/frontend/src/components/InvoicePrintOverlay.jsx
@@ -36,8 +36,14 @@ function mapApiInvoiceToInvoicePDF(invoiceRaw, lab, clinic) {
   const vatRate = parseFloat(invoiceRaw.vat_rate || 0);
 
   const rawItems = invoiceRaw.items || [];
-  const jobsById = new Map((invoiceRaw.related_jobs || []).map((job) => [job.id, job]));
   const subtotal = rawItems.reduce((sum, item) => sum + (parseFloat(item.line_total || 0) || 0), 0);
+  const discountPercent = parseFloat(invoiceRaw.discount_percent || 0) || 0;
+  const discountAmount = parseFloat(invoiceRaw.discount_amount);
+  const exactDiscountAmount = Number.isFinite(discountAmount)
+    ? discountAmount
+    : subtotal * (discountPercent / 100);
+  const vatAmount = parseFloat(invoiceRaw.vat_amount || 0) || 0;
+  const totalAmount = parseFloat(invoiceRaw.total_amount || 0) || 0;
   const items = invoiceRaw.description_mode === 'custom'
     ? [{
         code: 'PRACE',
@@ -47,16 +53,14 @@ function mapApiInvoiceToInvoicePDF(invoiceRaw, lab, clinic) {
         unitPrice: subtotal,
         vat: vatRate,
       }]
-    : rawItems.map((item, i) => ({
-    code: item.description
-      ? item.description.replace(/\s+/g, '-').toUpperCase().slice(0, 10)
-      : `IT-${String(i + 1).padStart(3, '0')}`,
-    name: item.description || `Položka #${i + 1}`,
-    qty: parseFloat(item.quantity || 1),
-    unit: 'ks',
-    unitPrice: parseFloat(item.unit_price || 0),
-    vat: vatRate,
-  }));
+    : (invoiceRaw.patient_summaries || []).map((summary, i) => ({
+        code: `PAC-${String(i + 1).padStart(3, '0')}`,
+        name: summary.patient_name || `Pacient #${summary.patient_id}`,
+        qty: 1,
+        unit: 'pac.',
+        unitPrice: parseFloat(summary.total || 0),
+        vat: vatRate,
+      }));
 
   const fmtSk = (isoDate) => {
     if (!isoDate) return '—';
@@ -75,6 +79,14 @@ function mapApiInvoiceToInvoicePDF(invoiceRaw, lab, clinic) {
     dueAt: fmtSk(invoiceRaw.due_date),
     paymentMethod: 'Prevodom na účet',
     issuedBy: '',
+    subtotalAmount: subtotal,
+    discountPercent,
+    discountAmount: exactDiscountAmount,
+    taxableAmount: parseFloat(invoiceRaw.taxable_amount),
+    vatRate,
+    vatAmount,
+    totalAmount,
+    isVatPayer: vatRate > 0 || !!(lab && lab.is_vat_payer),
     notes: invoiceRaw.description_mode === 'custom' && invoiceRaw.show_patient_list
       ? 'Podrobný rozpis prác a pacientov je v prílohe faktúry.'
       : (invoiceRaw.note || ''),
@@ -82,14 +94,15 @@ function mapApiInvoiceToInvoicePDF(invoiceRaw, lab, clinic) {
     customer,
     items,
     patientRows: invoiceRaw.show_patient_list
-      ? rawItems.map((item) => {
-          const job = jobsById.get(item.job);
-          return {
-            patient: (job && job.patient_name) || 'Bez pacienta',
-            description: item.description || (job && job.description) || 'Práca',
-            qty: parseFloat(item.quantity || 1),
-            total: parseFloat(item.line_total || 0),
-          };
+      ? (invoiceRaw.appendix_rows || []).flatMap((row) => {
+          const procedures = row.procedures || [];
+          return procedures.map((procedure, index) => ({
+            patient: row.patient_name || 'Bez pacienta',
+            description: procedure.description || row.job_description || 'Práca',
+            qty: parseFloat(procedure.quantity || 1),
+            total: parseFloat(procedure.line_total || 0),
+            recipes: index === procedures.length - 1 ? (row.recipes || []) : [],
+          }));
         })
       : [],
   };
@@ -221,7 +234,18 @@ function InvoicePrintOverlay({ invoiceId, invoiceNumber, onClose }) {
           box-shadow: none !important;
           border-radius: 0 !important;
         }
+        .molaris-paper-page {
+          break-after: page !important;
+          page-break-after: always !important;
+        }
+        .molaris-paper-page:last-child {
+          break-after: auto !important;
+          page-break-after: auto !important;
+        }
         @page { margin: 0; size: A4 portrait; }
+      }
+      @media screen {
+        .molaris-paper-page:not(:last-child) { margin-bottom: 16px; }
       }
     `)
   );

--- a/frontend/src/components/InvoiceSections.jsx
+++ b/frontend/src/components/InvoiceSections.jsx
@@ -20,10 +20,21 @@ function useInvoiceFormData(invoice) {
 function useInvoiceLineItemsData(invoice) {
   return React.useMemo(() => {
     const lineItems = (invoice.lineItems && invoice.lineItems.length) ? invoice.lineItems : [];
-    const subtotal = lineItems.reduce((sum, line) => sum + (line.total || 0), 0);
-    const vatRate = (invoice.raw && invoice.raw.vat_rate != null) ? invoice.raw.vat_rate / 100 : 0.20;
-    const vat = subtotal * vatRate;
-    return { lineItems, subtotal, vatRate, vat, total: subtotal + vat };
+    const calculatedSubtotal = lineItems.reduce((sum, line) => sum + (line.total || 0), 0);
+    const raw = invoice.raw || {};
+    const subtotal = raw.subtotal_amount != null ? Number(raw.subtotal_amount) : calculatedSubtotal;
+    const discountPercent = Number(raw.discount_percent || 0);
+    const discount = raw.discount_amount != null
+      ? Number(raw.discount_amount)
+      : subtotal * (discountPercent / 100);
+    const vatRate = raw.vat_rate != null ? Number(raw.vat_rate) / 100 : 0;
+    const vat = raw.vat_amount != null
+      ? Number(raw.vat_amount)
+      : (subtotal - discount) * vatRate;
+    const total = raw.total_amount != null
+      ? Number(raw.total_amount)
+      : subtotal - discount + vat;
+    return { lineItems, subtotal, discountPercent, discount, vatRate, vat, total };
   }, [invoice]);
 }
 
@@ -31,6 +42,7 @@ function useInvoiceActionsData(invoice) {
   const status = invoice.status;
   return React.useMemo(() => ({
     canDownload: !!invoice.id,
+    canEmail: !!invoice.id && ['issued', 'paid'].includes(status),
     canIssue: !!invoice.id && status === 'draft',
     canMarkPaid: !!invoice.id && status === 'issued',
     canCancel: !!invoice.id && status !== 'paid' && status !== 'cancelled',
@@ -146,7 +158,7 @@ function InvoiceForm({ invoice }) {
 }
 
 function InvoiceLineItems({ invoice }) {
-  const { lineItems, subtotal, vatRate, vat, total } = useInvoiceLineItemsData(invoice);
+  const { lineItems, subtotal, discountPercent, discount, vatRate, vat, total } = useInvoiceLineItemsData(invoice);
   return React.createElement('div', null,
     React.createElement('h3', { style: { fontFamily: 'Plus Jakarta Sans,sans-serif', fontSize: 13, fontWeight: 700, color: '#1a2320', margin: '0 0 8px', letterSpacing: '-0.01em' } }, 'Položky faktúry'),
     lineItems.length === 0
@@ -166,6 +178,10 @@ function InvoiceLineItems({ invoice }) {
               React.createElement('span', null, 'Medzisúčet'),
               React.createElement('span', null, fmtEur(subtotal))
             ),
+            discountPercent > 0 && React.createElement('div', { style: { display: 'flex', justifyContent: 'space-between', color: '#5a6b66' } },
+              React.createElement('span', null, `Zľava ${discountPercent} %`),
+              React.createElement('span', null, `−${fmtEur(discount)}`)
+            ),
             React.createElement('div', { style: { display: 'flex', justifyContent: 'space-between', color: '#5a6b66' } },
               React.createElement('span', null, `DPH ${Math.round(vatRate * 100)} %`),
               React.createElement('span', null, fmtEur(vat))
@@ -184,6 +200,7 @@ function InvoiceActions({ invoice, compact = false, onView, onError, onClose }) 
   const [confirmAction, setConfirmAction] = React.useState(null);
   const [printOpen, setPrintOpen] = React.useState(false);
   const [busy, setBusy] = React.useState(false);
+  const [emailSent, setEmailSent] = React.useState('');
   const openPrint = () => { if (actions.canDownload) setPrintOpen(true); };
 
   const runConfirmedAction = async () => {
@@ -224,6 +241,25 @@ function InvoiceActions({ invoice, compact = false, onView, onError, onClose }) 
     });
   };
 
+  const askEmail = () => {
+    const recipient = invoice.raw && invoice.raw.clinic_email;
+    if (!recipient) {
+      if (onError) onError('Klinika nemá nastavený kontaktný e-mail. Doplňte ho v detaile kliniky.');
+      return;
+    }
+    setConfirmAction({
+      title: 'Poslať faktúru klinike',
+      message: `Faktúra ${invoice.number} vrátane prílohy s pacientmi, úkonmi a receptami sa odošle na ${recipient}.`,
+      confirmText: 'Poslať e-mail',
+      destructive: false,
+      error: 'Faktúru sa nepodarilo odoslať. Skontrolujte e-mail kliniky a nastavenie odosielania.',
+      run: async () => {
+        const result = await window.MolarisAPI.sendInvoiceEmail(invoice.id);
+        setEmailSent(result.sent_to || 'kontaktný e-mail kliniky');
+      },
+    });
+  };
+
   const dialog = React.createElement(ConfirmDialog, {
     open: !!confirmAction,
     title: confirmAction && confirmAction.title,
@@ -240,6 +276,12 @@ function InvoiceActions({ invoice, compact = false, onView, onError, onClose }) 
       React.createElement(IconButton, { key: 'view', name: 'eye', title: 'Detail', onClick: () => onView && onView(invoice) }),
       React.createElement(IconButton, { key: 'pdf', name: 'download', title: 'Náhľad / PDF', onClick: openPrint }),
     ];
+    if (actions.canEmail) compactActions.push(React.createElement(IconButton, {
+      key: 'email',
+      name: 'mail',
+      title: emailSent ? `Odoslané: ${emailSent}` : 'Poslať klinike e-mailom',
+      onClick: askEmail,
+    }));
     if (actions.canIssue) compactActions.push(React.createElement(IconButton, {
       key: 'issue',
       name: 'send',
@@ -280,6 +322,12 @@ function InvoiceActions({ invoice, compact = false, onView, onError, onClose }) 
       React.createElement(Icon, { name: 'printer', size: 14 }),
       'Náhľad PDF'
     ),
+    actions.canEmail && React.createElement(Button, {
+      key: 'email',
+      variant: 'outline',
+      onClick: askEmail,
+      disabled: busy,
+    }, React.createElement(Icon, { name: 'mail', size: 14 }), emailSent ? `Odoslané: ${emailSent}` : 'Poslať klinike'),
     actions.canIssue && React.createElement(Button, {
       key: 'issue',
       onClick: () => askStatus('issued', 'Vystaviť faktúru', `Faktúra ${invoice.number} bude označená ako vystavená a vstúpi do pohľadávok.`, 'Vystaviť', 'Faktúru sa nepodarilo vystaviť.'),

--- a/frontend/src/components/invoice-pdf.jsx
+++ b/frontend/src/components/invoice-pdf.jsx
@@ -67,6 +67,7 @@ const DEFAULT_INVOICE = {
   ],
   notes: 'Práce boli zhotovené podľa zaslaných odtlačkov a sprievodnej karty č. 2025/142. Pri reklamácii prosíme priložiť pôvodnú prácu a popis závady.',
   issuedBy: 'Martin Kováč',
+  isVatPayer: true,
 };
 
 // Fake but plausible PAY-by-square QR — deterministic from seed.
@@ -116,6 +117,7 @@ function FakeQR({ size = 110, seed = 1, color = '#1a2320' }) {
 
 function PaperFrame({ children, watermark }) {
   return React.createElement('div', {
+    className: 'molaris-paper-page',
     style: {
       width: PAPER_W,
       height: PAPER_H,
@@ -362,28 +364,39 @@ function ItemsTable({ items }) {
         React.createElement('div', { style: { color: INK, fontWeight: 600 } }, it.name),
         React.createElement('div', { style: { color: INK_MUTED, fontSize: 9, marginTop: 1, letterSpacing: '0.04em' } }, 'Kód: ' + it.code)
       ),
-      React.createElement('span', { style: { textAlign: 'right', color: INK } }, it.qty),
-      React.createElement('span', { style: { textAlign: 'center', color: INK_SOFT } }, it.unit),
-      React.createElement('span', { style: { textAlign: 'right', color: INK } }, fmtEurPlain(it.unitPrice)),
-      React.createElement('span', { style: { textAlign: 'right', color: INK_SOFT } }, it.vat + ' %'),
+      React.createElement('span', { style: { textAlign: 'right', color: INK } }, it.continuation ? '—' : it.qty),
+      React.createElement('span', { style: { textAlign: 'center', color: INK_SOFT } }, it.continuation ? '—' : it.unit),
+      React.createElement('span', { style: { textAlign: 'right', color: INK } }, it.continuation ? '—' : fmtEurPlain(it.unitPrice)),
+      React.createElement('span', { style: { textAlign: 'right', color: INK_SOFT } }, it.continuation ? '—' : it.vat + ' %'),
       React.createElement('span', {
         style: { textAlign: 'right', color: INK, fontWeight: 700, fontFamily: "'Plus Jakarta Sans', sans-serif" }
-      }, fmtEurPlain(it.qty * it.unitPrice)),
+      }, it.continuation ? '—' : fmtEurPlain(it.qty * it.unitPrice)),
     )),
   );
 }
 
-function TotalsBlock({ items, skonto }) {
-  const subtotal = items.reduce((s, it) => s + it.qty * it.unitPrice, 0);
-  const vat = items.reduce((s, it) => s + it.qty * it.unitPrice * (it.vat / 100), 0);
-  const total = subtotal + vat;
-  const skontoAmount = skonto && skonto.enabled ? total * (skonto.percent / 100) : 0;
-  const discounted = total - skontoAmount;
+function TotalsBlock({ invoice }) {
+  const calculatedSubtotal = invoice.items.reduce((s, it) => s + it.qty * it.unitPrice, 0);
+  const subtotal = invoice.subtotalAmount == null ? calculatedSubtotal : invoice.subtotalAmount;
+  const discountPercent = invoice.discountPercent || 0;
+  const discountAmount = invoice.discountAmount == null
+    ? subtotal * (discountPercent / 100)
+    : invoice.discountAmount;
+  const taxable = Number.isFinite(invoice.taxableAmount)
+    ? invoice.taxableAmount
+    : subtotal - discountAmount;
+  const vatRate = invoice.vatRate == null
+    ? ((invoice.items[0] && invoice.items[0].vat) || 0)
+    : invoice.vatRate;
+  const calculatedVat = taxable * (vatRate / 100);
+  const vat = invoice.vatAmount == null ? calculatedVat : invoice.vatAmount;
+  const total = invoice.totalAmount == null ? taxable + vat : invoice.totalAmount;
 
   return React.createElement('div', { style: { display: 'flex', justifyContent: 'flex-end' } },
     React.createElement('div', { style: { width: 320, fontVariantNumeric: 'tabular-nums' } },
       React.createElement(TotalRow, { label: 'Medzisúčet (bez DPH)', value: fmtEur(subtotal) }),
-      React.createElement(TotalRow, { label: 'DPH 20 %',              value: fmtEur(vat) }),
+      discountPercent > 0 && React.createElement(TotalRow, { label: `Zľava ${discountPercent} %`, value: `−${fmtEur(discountAmount)}` }),
+      React.createElement(TotalRow, { label: `DPH ${vatRate} %`, value: fmtEur(vat) }),
       React.createElement('div', { style: { height: 1, background: RULE, margin: '6px 0' } }),
       React.createElement('div', {
         style: {
@@ -529,7 +542,9 @@ function FooterBlock({ invoice }) {
       ),
       React.createElement('div', {
         style: { fontSize: 9, color: INK_MUTED, marginTop: 14, lineHeight: 1.5 }
-      }, 'Dodávateľ je platiteľom DPH. Doklad je vystavený v zmysle zákona č. 222/2004 Z. z. o DPH.')
+      }, invoice.isVatPayer
+        ? 'Dodávateľ je platiteľom DPH. Doklad je vystavený v zmysle zákona č. 222/2004 Z. z. o DPH.'
+        : 'Dodávateľ nie je platiteľom DPH.')
     ),
     React.createElement('div', { style: { textAlign: 'right' } },
       React.createElement('div', {
@@ -543,83 +558,242 @@ function FooterBlock({ invoice }) {
   );
 }
 
-function PatientListAppendix({ invoice }) {
-  const rows = invoice.patientRows || [];
-  if (!rows.length) return null;
-  return React.createElement(PaperFrame, null,
-    React.createElement(HeaderBand, { supplier: invoice.supplier, showSupplierLogo: false }),
-    React.createElement(TitleRow, {
-      title: 'Príloha k faktúre',
-      subtitle: 'Rozpis pacientov a prác',
-      number: invoice.number,
-    }),
-    React.createElement('div', {
-      style: {
-        display: 'grid',
-        gridTemplateColumns: '1.2fr 1.8fr 70px 110px',
-        padding: '10px 10px',
-        background: INK,
-        color: '#fff',
-        fontSize: 9,
-        textTransform: 'uppercase',
-        letterSpacing: '0.08em',
-        fontWeight: 700,
-        borderRadius: '6px 6px 0 0',
+function chunkByWeight(entries, maxWeight) {
+  const chunks = [];
+  let current = [];
+  let weight = 0;
+  entries.forEach((entry) => {
+    const entryWeight = Math.max(1, entry.weight || 1);
+    if (current.length && weight + entryWeight > maxWeight) {
+      chunks.push(current);
+      current = [];
+      weight = 0;
+    }
+    current.push(entry);
+    weight += entryWeight;
+  });
+  if (current.length) chunks.push(current);
+  return chunks;
+}
+
+function appendixEntries(rows) {
+  const entries = [];
+  rows.forEach((row, rowIndex) => {
+    entries.push({
+      type: 'procedure',
+      key: `procedure-${rowIndex}`,
+      row,
+      weight: 1 + Math.ceil(`${row.patient} ${row.description}`.length / 90),
+    });
+    (row.recipes || []).forEach((recipe, recipeIndex) => {
+      entries.push({
+        type: 'recipe',
+        key: `recipe-${rowIndex}-${recipeIndex}`,
+        patient: row.patient,
+        recipe,
+        weight: 1 + Math.ceil(`${row.patient} ${recipe.name}`.length / 100),
+      });
+      const materials = recipe.materials || [];
+      if (!materials.length) {
+        entries.push({
+          type: 'material-empty',
+          key: `material-empty-${rowIndex}-${recipeIndex}`,
+          weight: 1,
+        });
       }
-    },
-      React.createElement('span', null, 'Pacient'),
-      React.createElement('span', null, 'Práca'),
-      React.createElement('span', { style: { textAlign: 'right' } }, 'Množ.'),
-      React.createElement('span', { style: { textAlign: 'right' } }, 'Spolu')
-    ),
-    ...rows.map((row, index) => React.createElement('div', {
-      key: index,
+      materials.forEach((material, materialIndex) => {
+        const text = [
+          material.name,
+          material.lot ? `LOT ${material.lot}` : '',
+          material.manufacturer || '',
+        ].filter(Boolean).join(' · ');
+        entries.push({
+          type: 'material',
+          key: `material-${rowIndex}-${recipeIndex}-${materialIndex}`,
+          material,
+          text,
+          weight: 1 + Math.ceil(text.length / 95),
+        });
+      });
+    });
+  });
+  return entries;
+}
+
+function AppendixTableHeader() {
+  return React.createElement('div', {
+    style: {
+      display: 'grid',
+      gridTemplateColumns: '1.2fr 1.8fr 70px 110px',
+      padding: '10px 10px',
+      background: INK,
+      color: '#fff',
+      fontSize: 9,
+      textTransform: 'uppercase',
+      letterSpacing: '0.08em',
+      fontWeight: 700,
+      borderRadius: '6px 6px 0 0',
+    }
+  },
+    React.createElement('span', null, 'Pacient'),
+    React.createElement('span', null, 'Práca / recept / materiál'),
+    React.createElement('span', { style: { textAlign: 'right' } }, 'Množ.'),
+    React.createElement('span', { style: { textAlign: 'right' } }, 'Spolu')
+  );
+}
+
+function AppendixEntry({ entry, index }) {
+  if (entry.type === 'procedure') {
+    const row = entry.row;
+    return React.createElement('div', {
       style: {
         display: 'grid',
         gridTemplateColumns: '1.2fr 1.8fr 70px 110px',
-        padding: '10px 10px',
+        padding: '9px 10px',
+        fontSize: 10,
+        alignItems: 'baseline',
         borderBottom: `1px solid ${RULE_SOFT}`,
         background: index % 2 === 0 ? '#fff' : '#fbfaf6',
-        fontSize: 10.5,
-        alignItems: 'baseline',
       }
     },
       React.createElement('span', { style: { color: INK, fontWeight: 600 } }, row.patient),
-      React.createElement('span', { style: { color: INK_SOFT } }, row.description),
+      React.createElement('span', { style: { color: INK_SOFT, overflowWrap: 'anywhere' } }, row.description),
       React.createElement('span', { style: { textAlign: 'right', color: INK } }, row.qty),
       React.createElement('span', { style: { textAlign: 'right', color: INK, fontWeight: 700 } }, fmtEurPlain(row.total))
+    );
+  }
+
+  if (entry.type === 'recipe') {
+    const recipe = entry.recipe;
+    const parsedDate = recipe.date ? new Date(recipe.date) : null;
+    const dateLabel = parsedDate && !Number.isNaN(parsedDate.getTime())
+      ? ` · ${parsedDate.toLocaleDateString('sk-SK')}`
+      : (recipe.date ? ` · ${recipe.date}` : '');
+    return React.createElement('div', {
+      style: {
+        margin: '5px 10px 2px',
+        padding: '7px 9px',
+        borderLeft: `3px solid ${TEAL}`,
+        background: '#f3f8f6',
+        color: INK,
+        fontSize: 9.5,
+        fontWeight: 700,
+        overflowWrap: 'anywhere',
+      }
+    }, entry.patient, ' · Recept: ', recipe.name, dateLabel);
+  }
+
+  if (entry.type === 'material-empty') {
+    return React.createElement('div', {
+      style: { margin: '0 22px 5px', color: INK_MUTED, fontSize: 8.5 }
+    }, 'Bez materiálových riadkov');
+  }
+
+  const material = entry.material;
+  return React.createElement('div', {
+    style: {
+      display: 'grid',
+      gridTemplateColumns: '1fr 110px',
+      gap: 12,
+      margin: '0 22px',
+      padding: '5px 0',
+      borderBottom: `1px solid ${RULE_SOFT}`,
+      color: INK_SOFT,
+      fontSize: 8.5,
+    }
+  },
+    React.createElement('span', { style: { overflowWrap: 'anywhere' } }, entry.text),
+    React.createElement('span', { style: { textAlign: 'right', color: INK } }, `${material.quantity} ${material.unit}`)
+  );
+}
+
+function PatientListAppendix({ invoice }) {
+  const rows = invoice.patientRows || [];
+  if (!rows.length) return null;
+  const pages = chunkByWeight(appendixEntries(rows), 17);
+  return React.createElement(React.Fragment, null,
+    ...pages.map((entries, pageIndex) => React.createElement(PaperFrame, { key: `appendix-${pageIndex}` },
+      React.createElement(HeaderBand, { supplier: invoice.supplier, showSupplierLogo: false }),
+      React.createElement(TitleRow, {
+        title: 'Príloha k faktúre',
+        subtitle: `Rozpis pacientov, prác a receptov · strana ${pageIndex + 1}/${pages.length}`,
+        number: invoice.number,
+      }),
+      React.createElement(AppendixTableHeader),
+      ...entries.map((entry, index) => React.createElement(AppendixEntry, {
+        key: entry.key,
+        entry,
+        index,
+      }))
     ))
   );
 }
 
 // ─── Main components ──────────────────────────────────────────────────
 
-function InvoicePDF({ invoice = DEFAULT_INVOICE, skonto = null, showSupplierLogo = true }) {
-  const subtotal = invoice.items.reduce((s, it) => s + it.qty * it.unitPrice, 0);
-  const vat = invoice.items.reduce((s, it) => s + it.qty * it.unitPrice * (it.vat / 100), 0);
-  const total = subtotal + vat;
+function chunkItems(items, size = 5) {
+  const chunks = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks.length ? chunks : [[]];
+}
 
+function splitItemDescriptions(items, maxLength = 280) {
+  return items.flatMap((item) => {
+    const text = String(item.name || '');
+    if (text.length <= maxLength) return [item];
+    const words = text.split(/\s+/);
+    const parts = [];
+    let part = '';
+    words.forEach((word) => {
+      if (part && `${part} ${word}`.length > maxLength) {
+        parts.push(part);
+        part = word;
+      } else {
+        part = part ? `${part} ${word}` : word;
+      }
+    });
+    if (part) parts.push(part);
+    return parts.map((name, index) => ({
+      ...item,
+      name,
+      code: index === 0 ? item.code : `${item.code}-POK`,
+      continuation: index > 0,
+    }));
+  });
+}
+
+function InvoicePDF({ invoice = DEFAULT_INVOICE, skonto = null, showSupplierLogo = true }) {
+  const total = invoice.totalAmount == null
+    ? invoice.items.reduce((s, it) => s + it.qty * it.unitPrice * (1 + it.vat / 100), 0)
+    : invoice.totalAmount;
+
+  const pages = chunkItems(splitItemDescriptions(invoice.items));
   return React.createElement(React.Fragment, null,
-    React.createElement(PaperFrame, null,
-      React.createElement(HeaderBand, { supplier: invoice.supplier, showSupplierLogo }),
-      React.createElement(TitleRow, {
-        title: 'Faktúra',
-        subtitle: invoice.type,
-        number: invoice.number,
-      }),
-      React.createElement('div', {
-        style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 32, marginBottom: 22 }
-      },
-        React.createElement(PartyBlock, { label: 'Dodávateľ', party: invoice.supplier }),
-        React.createElement(PartyBlock, { label: 'Odberateľ', party: invoice.customer }),
-      ),
-      React.createElement(MetaGrid, { invoice }),
-      React.createElement(ItemsTable, { items: invoice.items }),
-      React.createElement(TotalsBlock, { items: invoice.items, skonto }),
-      React.createElement(SkontoCallout, { skonto, items: invoice.items }),
-      React.createElement(PaymentBlock, { supplier: invoice.supplier, invoice, total }),
-      React.createElement(FooterBlock, { invoice }),
-    ),
+    ...pages.map((items, pageIndex) => {
+      const lastPage = pageIndex === pages.length - 1;
+      return React.createElement(PaperFrame, { key: `invoice-${pageIndex}` },
+        React.createElement(HeaderBand, { supplier: invoice.supplier, showSupplierLogo }),
+        React.createElement(TitleRow, {
+          title: 'Faktúra',
+          subtitle: pages.length > 1 ? `${invoice.type} · strana ${pageIndex + 1}/${pages.length}` : invoice.type,
+          number: invoice.number,
+        }),
+        React.createElement('div', {
+          style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 32, marginBottom: 22 }
+        },
+          React.createElement(PartyBlock, { label: 'Dodávateľ', party: invoice.supplier }),
+          React.createElement(PartyBlock, { label: 'Odberateľ', party: invoice.customer }),
+        ),
+        React.createElement(MetaGrid, { invoice }),
+        React.createElement(ItemsTable, { items }),
+        lastPage && React.createElement(TotalsBlock, { invoice }),
+        lastPage && React.createElement(SkontoCallout, { skonto, items: invoice.items }),
+        lastPage && React.createElement(PaymentBlock, { supplier: invoice.supplier, invoice, total }),
+        lastPage && React.createElement(FooterBlock, { invoice })
+      );
+    }),
     React.createElement(PatientListAppendix, { invoice })
   );
 }
@@ -632,45 +806,50 @@ function ProformaPDF({ invoice = DEFAULT_INVOICE, showSupplierLogo = true }) {
     variableSymbol: '9' + invoice.variableSymbol.slice(1),
     type: 'Predfaktúra — výzva na úhradu (nie je daňový doklad)',
   };
-  const subtotal = proformaInvoice.items.reduce((s, it) => s + it.qty * it.unitPrice, 0);
-  const vat = proformaInvoice.items.reduce((s, it) => s + it.qty * it.unitPrice * (it.vat / 100), 0);
-  const total = subtotal + vat;
+  const total = proformaInvoice.totalAmount == null
+    ? proformaInvoice.items.reduce((s, it) => s + it.qty * it.unitPrice * (1 + it.vat / 100), 0)
+    : proformaInvoice.totalAmount;
 
+  const pages = chunkItems(splitItemDescriptions(proformaInvoice.items));
   return React.createElement(React.Fragment, null,
-    React.createElement(PaperFrame, {
-      watermark: React.createElement(Watermark, { text: 'PREDFAKTÚRA' })
-    },
-      React.createElement(HeaderBand, { supplier: proformaInvoice.supplier, showSupplierLogo }),
-      React.createElement(TitleRow, {
-        title: 'Predfaktúra',
-        subtitle: proformaInvoice.type,
-        number: proformaInvoice.number,
-        accent: TEAL,
-      }),
-      React.createElement('div', {
-        style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 32, marginBottom: 22 }
+    ...pages.map((items, pageIndex) => {
+      const lastPage = pageIndex === pages.length - 1;
+      return React.createElement(PaperFrame, {
+        key: `proforma-${pageIndex}`,
+        watermark: React.createElement(Watermark, { text: 'PREDFAKTÚRA' })
       },
-        React.createElement(PartyBlock, { label: 'Dodávateľ', party: proformaInvoice.supplier }),
-        React.createElement(PartyBlock, { label: 'Odberateľ', party: proformaInvoice.customer }),
-      ),
-      React.createElement(MetaGrid, { invoice: proformaInvoice }),
-      React.createElement(ItemsTable, { items: proformaInvoice.items }),
-      React.createElement(TotalsBlock, { items: proformaInvoice.items, skonto: null }),
-      React.createElement(PaymentBlock, { supplier: proformaInvoice.supplier, invoice: proformaInvoice, total }),
-      React.createElement('div', {
-        style: {
-          marginTop: 18, padding: '10px 14px',
-          background: TEAL_SUBTLE, border: `1px solid #b8e2d7`, borderRadius: 6,
-          fontSize: 10, color: TEAL_DARK, lineHeight: 1.5,
-        }
-      },
-        React.createElement('strong', {
-          style: { fontFamily: "'Plus Jakarta Sans', sans-serif", letterSpacing: '0.02em' }
-        }, 'Upozornenie: '),
-        'Tento doklad nie je daňový doklad. Po prijatí platby Vám zašleme riadnu faktúru — daňový doklad v zákonnej lehote.'
-      ),
-      React.createElement(FooterBlock, { invoice: proformaInvoice }),
-    ),
+        React.createElement(HeaderBand, { supplier: proformaInvoice.supplier, showSupplierLogo }),
+        React.createElement(TitleRow, {
+          title: 'Predfaktúra',
+          subtitle: pages.length > 1 ? `${proformaInvoice.type} · strana ${pageIndex + 1}/${pages.length}` : proformaInvoice.type,
+          number: proformaInvoice.number,
+          accent: TEAL,
+        }),
+        React.createElement('div', {
+          style: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 32, marginBottom: 22 }
+        },
+          React.createElement(PartyBlock, { label: 'Dodávateľ', party: proformaInvoice.supplier }),
+          React.createElement(PartyBlock, { label: 'Odberateľ', party: proformaInvoice.customer }),
+        ),
+        React.createElement(MetaGrid, { invoice: proformaInvoice }),
+        React.createElement(ItemsTable, { items }),
+        lastPage && React.createElement(TotalsBlock, { invoice: proformaInvoice }),
+        lastPage && React.createElement(PaymentBlock, { supplier: proformaInvoice.supplier, invoice: proformaInvoice, total }),
+        lastPage && React.createElement('div', {
+          style: {
+            marginTop: 18, padding: '10px 14px',
+            background: TEAL_SUBTLE, border: `1px solid #b8e2d7`, borderRadius: 6,
+            fontSize: 10, color: TEAL_DARK, lineHeight: 1.5,
+          }
+        },
+          React.createElement('strong', {
+            style: { fontFamily: "'Plus Jakarta Sans', sans-serif", letterSpacing: '0.02em' }
+          }, 'Upozornenie: '),
+          'Tento doklad nie je daňový doklad. Po prijatí platby Vám zašleme riadnu faktúru — daňový doklad v zákonnej lehote.'
+        ),
+        lastPage && React.createElement(FooterBlock, { invoice: proformaInvoice })
+      );
+    }),
     React.createElement(PatientListAppendix, { invoice: proformaInvoice })
   );
 }


### PR DESCRIPTION
## What changed

- adds the two required invoice modes: patient-based summaries and custom free-text billing
- generates patient appendices with procedures, recipes, materials, LOT numbers and quantities
- snapshots invoice breakdown data so issued documents do not change when source patient/job/material records change
- fixes discount, VAT, taxable amount and total consistency across API, detail UI and PDF preview
- paginates long invoice bodies and appendices in both ReportLab PDFs and the browser A4 preview without truncating content
- adds direct clinic email delivery with the exact recipient shown before confirmation and safer delivery error handling
- uses a lightweight, bounded invoice collection response while keeping detailed clinical data on the detail endpoint
- includes a data migration for existing invoices

## Why

The previous implementation could render totals differently between UI and backend, truncate long content, clip large appendices, expose live mutable patient/material data on historical invoices, and did not offer a complete clinic-email workflow.

## Impact

Dental laboratories can now create either patient-visible or discreet free-text invoices while always retaining a complete clinical appendix. Historical invoice content remains stable and large documents produce valid multi-page output.

## Validation

- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test apps.finance --noinput --verbosity=0` — 151 passed
- targeted multi-page PDF regression tests — passed
- `npm run lint` — 0 errors (existing unrelated warnings only)
- `npm run build`
- `npx playwright test e2e/invoice-flow.spec.js` — 2 passed
- migration `finance.0012_invoice_breakdown_snapshot` applied successfully in the development stack
